### PR TITLE
Document MCP tool request and error examples

### DIFF
--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -25,13 +25,32 @@ Connect to the ToM network. **Must be called before other operations.**
 
 **Parameters:** None
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_connect",
+    "arguments": {}
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "status": "connected",
-  "nodeId": "abc123...",
-  "username": "mcp-agent",
-  "signalingUrl": "ws://localhost:3001"
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"status\": \"connected\",\n  \"nodeId\": \"abc123...\",\n  \"username\": \"mcp-agent\",\n  \"signalingUrl\": \"ws://localhost:3001\"\n}"
+      }
+    ]
+  }
 }
 ```
 
@@ -43,9 +62,28 @@ Disconnect from the ToM network.
 
 **Parameters:** None
 
-**Response:**
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_disconnect",
+    "arguments": {}
+  }
+}
 ```
-Disconnected from ToM network
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [{ "type": "text", "text": "Disconnected from ToM network" }]
+  }
+}
 ```
 
 ---
@@ -68,19 +106,53 @@ Send a message to another participant.
 }
 ```
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_send_message",
+    "arguments": {
+      "to": "alice",
+      "message": "Hello from the MCP server!"
+    }
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "status": "sent",
-  "messageId": "msg-abc123",
-  "to": "node-id-xyz",
-  "message": "Hello from the MCP server!"
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"status\": \"sent\",\n  \"messageId\": \"msg-abc123\",\n  \"to\": \"node-id-xyz\",\n  \"message\": \"Hello from the MCP server!\"\n}"
+      }
+    ]
+  }
 }
 ```
 
 **Error (recipient not found):**
-```
-Error: Participant not found: bob. Available: alice, charlie
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Error: Participant not found: bob. Available: alice, charlie"
+      }
+    ],
+    "isError": true
+  }
+}
 ```
 
 ---
@@ -91,24 +163,32 @@ List all currently connected participants.
 
 **Parameters:** None
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_list_participants",
+    "arguments": {}
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "count": 3,
-  "participants": [
-    {
-      "nodeId": "abc123...",
-      "username": "alice",
-      "roles": ["client", "relay"],
-      "status": "online"
-    },
-    {
-      "nodeId": "def456...",
-      "username": "bob",
-      "roles": ["client"],
-      "status": "online"
-    }
-  ]
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"count\": 2,\n  \"participants\": [\n    {\n      \"nodeId\": \"abc123...\",\n      \"username\": \"alice\",\n      \"roles\": [\"client\", \"relay\"],\n      \"status\": \"online\"\n    },\n    {\n      \"nodeId\": \"def456...\",\n      \"username\": \"bob\",\n      \"roles\": [\"client\"],\n      \"status\": \"online\"\n    }\n  ]\n}"
+      }
+    ]
+  }
 }
 ```
 
@@ -120,22 +200,31 @@ Get current network status including role, peers, and statistics.
 
 **Parameters:** None
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_get_network_status",
+    "arguments": {}
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "nodeId": "abc123...",
-  "username": "mcp-agent",
-  "roles": ["client", "relay"],
-  "connectedPeers": 5,
-  "gossip": {
-    "totalPeers": 8,
-    "bootstrapPeers": 3,
-    "gossipPeers": 5,
-    "connectedPeers": 5
-  },
-  "subnets": {
-    "totalSubnets": 2,
-    "totalNodesInSubnets": 4
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"nodeId\": \"abc123...\",\n  \"username\": \"mcp-agent\",\n  \"roles\": [\"client\", \"relay\"],\n  \"connectedPeers\": 5,\n  \"gossip\": {\n    \"totalPeers\": 8,\n    \"bootstrapPeers\": 3,\n    \"gossipPeers\": 5,\n    \"connectedPeers\": 5\n  },\n  \"subnets\": {\n    \"totalSubnets\": 2,\n    \"totalNodesInSubnets\": 4\n  }\n}"
+      }
+    ]
   }
 }
 ```
@@ -151,28 +240,34 @@ Get recent message history (sent and received).
 |------|------|----------|-------------|
 | `limit` | number | No | Max messages to return (default: 20, max: 1000) |
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_get_message_history",
+    "arguments": {
+      "limit": 2
+    }
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "count": 2,
-  "messages": [
-    {
-      "id": "msg-123",
-      "from": "abc123...",
-      "to": "def456...",
-      "text": "Hello!",
-      "timestamp": "2026-02-06T10:30:00.000Z",
-      "status": "sent"
-    },
-    {
-      "id": "msg-456",
-      "from": "def456...",
-      "to": "abc123...",
-      "text": "Hi there!",
-      "timestamp": "2026-02-06T10:30:05.000Z",
-      "status": "received"
-    }
-  ]
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"count\": 2,\n  \"messages\": [\n    {\n      \"id\": \"msg-123\",\n      \"from\": \"abc123...\",\n      \"to\": \"def456...\",\n      \"text\": \"Hello!\",\n      \"timestamp\": \"2026-02-06T10:30:00.000Z\",\n      \"status\": \"sent\"\n    },\n    {\n      \"id\": \"msg-456\",\n      \"from\": \"def456...\",\n      \"to\": \"abc123...\",\n      \"text\": \"Hi there!\",\n      \"timestamp\": \"2026-02-06T10:30:05.000Z\",\n      \"status\": \"received\"\n    }\n  ]\n}"
+      }
+    ]
+  }
 }
 ```
 
@@ -184,14 +279,32 @@ Get peer discovery statistics from the gossip protocol.
 
 **Parameters:** None
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_get_gossip_stats",
+    "arguments": {}
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "totalPeers": 12,
-  "bootstrapPeers": 4,
-  "gossipPeers": 8,
-  "connectedPeers": 10,
-  "bootstrapDependency": "33.3%"
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"totalPeers\": 12,\n  \"bootstrapPeers\": 4,\n  \"gossipPeers\": 8,\n  \"connectedPeers\": 10,\n  \"bootstrapDependency\": \"33.3%\"\n}"
+      }
+    ]
+  }
 }
 ```
 
@@ -205,22 +318,32 @@ Get ephemeral subnet statistics.
 
 **Parameters:** None
 
+**Example request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "tools/call",
+  "params": {
+    "name": "tom_get_subnet_stats",
+    "arguments": {}
+  }
+}
+```
+
 **Response:**
 ```json
 {
-  "totalSubnets": 2,
-  "totalNodesInSubnets": 6,
-  "averageSubnetSize": "3.0",
-  "communicationEdges": 8,
-  "subnets": [
-    {
-      "id": "subnet-abc",
-      "members": 3,
-      "formedAt": "2026-02-06T10:00:00.000Z",
-      "lastActivity": "2026-02-06T10:30:00.000Z",
-      "densityScore": "0.85"
-    }
-  ]
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"totalSubnets\": 2,\n  \"totalNodesInSubnets\": 6,\n  \"averageSubnetSize\": \"3.0\",\n  \"communicationEdges\": 8,\n  \"subnets\": [\n    {\n      \"id\": \"subnet-abc\",\n      \"members\": 3,\n      \"formedAt\": \"2026-02-06T10:00:00.000Z\",\n      \"lastActivity\": \"2026-02-06T10:30:00.000Z\",\n      \"densityScore\": \"0.85\"\n    }\n  ]\n}"
+      }
+    ]
+  }
 }
 ```
 
@@ -228,7 +351,7 @@ Get ephemeral subnet statistics.
 
 ## Error Handling
 
-All errors return structured responses:
+Tool errors return structured MCP tool results:
 
 ```json
 {
@@ -236,6 +359,32 @@ All errors return structured responses:
   "isError": true
 }
 ```
+
+JSON-RPC protocol errors return an `error` object:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "error": {
+    "code": -32601,
+    "message": "Method not found: unknown/method"
+  }
+}
+```
+
+Common error cases:
+
+| Case | Error shape |
+|------|-------------|
+| Invalid JSON input | JSON-RPC error `-32700`, `Parse error` |
+| Missing `method` field | JSON-RPC error `-32600`, `Invalid Request: must be an object with method` |
+| Unsupported JSON-RPC method | JSON-RPC error `-32601`, `Method not found: <method>` |
+| `tools/call` without `params.name` | JSON-RPC error `-32602`, `Invalid params: missing or invalid "name"` |
+| Unknown ToM tool name | Tool result with `isError: true` and `Error: Unknown tool: <name>` |
+| Tool called before `tom_connect` | Tool result with `isError: true` and `Error: Not connected. Call tom_connect first.` |
+| `tom_send_message` recipient missing | Tool result with `isError: true` and available participant names |
+| Tool execution exceeds 30 seconds | JSON-RPC error `-32603`, `Tool execution timed out after 30s` |
 
 ## Usage with Claude Desktop
 


### PR DESCRIPTION
## Summary

Adds concrete MCP `tools/call` request examples and response envelopes for the ToM MCP server tools documented in `tools/mcp-server/README.md`.

This is intended to close #10's request for request/response examples and error case documentation.

## Details

- Adds an example JSON-RPC `tools/call` request for each documented `tom_*` tool.
- Shows representative MCP tool-result response envelopes, including `content` text payloads and `isError` for tool-level failures.
- Expands the error handling section with the difference between tool-result errors and JSON-RPC protocol errors.
- Documents common error cases from the current CLI/server implementation.

## Validation

- `git diff --check`
- Parsed all fenced `json` blocks in `tools/mcp-server/README.md` with Python `json.loads`.

I did not run the repo test suite here because `pnpm` is not installed in this environment; a transient `npx pnpm` attempt selected a pnpm version requiring Node 22 while this runner has Node 18.
