### PR TITLE
fix(securite): triage rand + lru — RUSTSEC-2026-0002 corrigé pour notre usage direct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5253,7 +5253,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519-dalek 2.2.0",
  "hkdf",
- "lru 0.12.5",
+ "lru 0.16.3",
  "n0-future",
  "proptest",
  "rand 0.9.2",

--- a/crates/tom-protocol-ffi/Cargo.lock
+++ b/crates/tom-protocol-ffi/Cargo.lock
@@ -1364,8 +1364,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2084,15 +2082,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -2135,7 +2124,7 @@ dependencies = [
  "flume",
  "futures-lite",
  "getrandom 0.4.2",
- "lru 0.16.3",
+ "lru",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -2703,7 +2692,7 @@ dependencies = [
  "futures-lite",
  "getrandom 0.4.2",
  "log",
- "lru 0.16.3",
+ "lru",
  "ntimestamp",
  "reqwest 0.13.2",
  "self_cell",
@@ -4158,7 +4147,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519-dalek 2.2.0",
  "hkdf",
- "lru 0.12.5",
+ "lru",
  "n0-future",
  "rmp-serde",
  "rusqlite",
@@ -4257,7 +4246,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "iroh-metrics",
- "lru 0.16.3",
+ "lru",
  "n0-error",
  "n0-future",
  "num_enum",

--- a/crates/tom-protocol/Cargo.toml
+++ b/crates/tom-protocol/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1"
 tom-metrics = { path = "../tom-metrics" }
 
 # Anti-spam (Phase R11.1)
-lru = "0.16"
+lru = "0.16.3" # min requise : RUSTSEC-2026-0002 corrigee a partir de 0.16.3 (review copilot PR #43)
 
 # Gossip discovery (Phase 3)
 tom-connect = { path = "../tom-connect" }

--- a/crates/tom-protocol/Cargo.toml
+++ b/crates/tom-protocol/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1"
 tom-metrics = { path = "../tom-metrics" }
 
 # Anti-spam (Phase R11.1)
-lru = "0.12"
+lru = "0.16"
 
 # Gossip discovery (Phase 3)
 tom-connect = { path = "../tom-connect" }

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,7 @@ ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki — name constraints URI (cf. triage)
     "RUSTSEC-2026-0099", # rustls-webpki — name constraints wildcard (cf. triage)
     "RUSTSEC-2026-0104", # rustls-webpki — panic parsing CRL (cf. triage)
-    "RUSTSEC-2026-0097", # rand 0.9.2 — unsound avec logger custom. Fix annoncé >=0.9.3 PAS ENCORE PUBLIÉ (cargo update sans effet, vérifié 2026-06-11). Exposition faible : pas de logger custom dans le workspace. À re-vérifier périodiquement.
+    "RUSTSEC-2026-0097", # rand 0.9.2 — unsound avec logger custom. Fix annoncé >=0.9.3 PAS ENCORE PUBLIÉ (cargo update sans effet, vérifié 2026-06-11). Exposition faible : pas de logger custom dans le workspace. À re-vérifier périodiquement. Nota : la contrainte rand de tom-gossip ("0.9.2" = caret ^0.9.2) acceptera 0.9.3 sans modification.
     "RUSTSEC-2026-0002", # lru IterMut unsound (le commentaire initial disait slab — erreur corrigée 2026-06-11). Usage DIRECT corrigé : tom-protocol bumpe lru 0.12→0.16.3. Reste lru 0.12.5 via ratatui 0.29 (tom-tui, UI seulement) — exposition : IterMut non utilisé par notre code.
     "RUSTSEC-2024-0436", # paste unmaintained — dep transitive, remplaçant: pastey
     "RUSTSEC-2023-0089", # atomic-polyfill unmaintained — dep transitive

--- a/deny.toml
+++ b/deny.toml
@@ -18,8 +18,8 @@ ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki — name constraints URI (cf. triage)
     "RUSTSEC-2026-0099", # rustls-webpki — name constraints wildcard (cf. triage)
     "RUSTSEC-2026-0104", # rustls-webpki — panic parsing CRL (cf. triage)
-    "RUSTSEC-2026-0097", # rand 0.9.2 — unsound avec logger custom (pas notre cas, à confirmer au triage)
-    "RUSTSEC-2026-0002", # IterMut unsound (slab) — exposition à évaluer au triage
+    "RUSTSEC-2026-0097", # rand 0.9.2 — unsound avec logger custom. Fix annoncé >=0.9.3 PAS ENCORE PUBLIÉ (cargo update sans effet, vérifié 2026-06-11). Exposition faible : pas de logger custom dans le workspace. À re-vérifier périodiquement.
+    "RUSTSEC-2026-0002", # lru IterMut unsound (le commentaire initial disait slab — erreur corrigée 2026-06-11). Usage DIRECT corrigé : tom-protocol bumpe lru 0.12→0.16.3. Reste lru 0.12.5 via ratatui 0.29 (tom-tui, UI seulement) — exposition : IterMut non utilisé par notre code.
     "RUSTSEC-2024-0436", # paste unmaintained — dep transitive, remplaçant: pastey
     "RUSTSEC-2023-0089", # atomic-polyfill unmaintained — dep transitive
 ]


### PR DESCRIPTION
## Contexte

Suite du triage des 10 advisories RustSec relevées au chantier S0.5 (`docs/plans/2026-06-10-chantier-s0-suivi.md`). Après les 4 webpki (PR #42), cette PR traite les 2 advisories *unsound*.

## Changements

### RUSTSEC-2026-0002 — lru `IterMut` unsound
- **Découverte** : le commentaire de deny.toml attribuait l'advisory à `slab` — c'était `lru`. Corrigé.
- **Fix réel** : `tom-protocol` bumpe `lru = "0.12" → "0.16"` (consommé dans `router.rs` et `roles/antispam.rs`) — compile **sans aucun changement de code**, 515 tests verts.
- **Ignore conservé avec justification** : ratatui 0.29 (tom-tui, couche UI) tire encore lru 0.12.5 ; `IterMut` n'est pas utilisé par notre code → exposition nulle. Se résoudra avec un futur bump ratatui.

### RUSTSEC-2026-0097 — rand unsound (logger custom)
- Le fix annoncé (≥0.9.3) **n'est pas publié** : `cargo update -p rand` reste sur 0.9.2 (vérifié 2026-06-11).
- Ignore maintenu, commentaire enrichi : analyse d'exposition (aucun logger custom dans le workspace) + consigne de re-vérification périodique.

## Vérifications

- `cargo deny check advisories` → ok
- `cargo clippy --workspace -- -D warnings` → vert
- `cargo test --workspace` (hors tom-integration-tests) → 0 échec

## Note de coordination

Cette branche part de `main` : `deny.toml` et `Cargo.lock` auront un conflit **trivial** avec PR #42 (webpki) — les deux retirent/annotent des lignes voisines. À résoudre au merge de la seconde (je ne merge pas, conformément au process).

## Restent au triage (4/10)

hickory-proto ×2 (bump majeur 0.26 — chantier dédié), paste/atomic-polyfill (unmaintained, transitifs, pas d'action possible sans bump amont).

🤖 Generated with [Claude Code](https://claude.com/claude-code)