### PR TITLE
fix(securite): batch advisories aws-lc du 2026-06-11 — débloque la CI des PR ouvertes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,12 +1814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5301,7 +5295,6 @@ dependencies = [
  "criterion",
  "directories-next",
  "futures-io",
- "gcc",
  "http",
  "iroh-quinn-udp 0.8.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,9 +394,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.11"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6ea8e07e2df15b9f09f2ac5ee2977369b06d116f0c4eb5fa4ad443b73c7f53"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
@@ -408,32 +408,20 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-fips-sys",
- "aws-lc-sys 0.37.1",
+ "aws-lc-sys",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -5305,7 +5293,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "aws-lc-fips-sys",
- "aws-lc-sys 0.34.0",
+ "aws-lc-sys",
  "bytes",
  "cfg_aliases",
  "clap",
@@ -5443,6 +5431,17 @@ dependencies = [
  "tom-relay",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tom-sdk"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tom-protocol",
+ "tom-transport",
 ]
 
 [[package]]

--- a/crates/tom-quinn/Cargo.toml
+++ b/crates/tom-quinn/Cargo.toml
@@ -146,10 +146,6 @@ version = "1"
 version = "0.3.19"
 optional = true
 
-[dependencies.gcc]
-version = "0.3.55"
-optional = true
-
 [dependencies.http]
 version = "1.1.0"
 optional = true

--- a/crates/tom-quinn/Cargo.toml
+++ b/crates/tom-quinn/Cargo.toml
@@ -135,7 +135,8 @@ optional = true
 [dependencies.aws-lc-sys]
 # 0.34 -> 0.41 : RUSTSEC 2026-0042..0048 (batch advisories AWS-LC du 2026-06-11).
 # Dep optionnelle (feature aws-lc-rs, non utilisee par les builds ToM) heritee
-# de l upstream iroh-quinn - bump de securite, cf. FORK-GOVERNANCE.md.
+# de l upstream iroh-quinn - bump de securite, cf. docs/FORK-GOVERNANCE.md
+# (chemin relatif a la racine du depot).
 version = "0.41"
 optional = true
 

--- a/crates/tom-quinn/Cargo.toml
+++ b/crates/tom-quinn/Cargo.toml
@@ -133,7 +133,10 @@ version = "0.13.10"
 optional = true
 
 [dependencies.aws-lc-sys]
-version = "0.34.0"
+# 0.34 -> 0.41 : RUSTSEC 2026-0042..0048 (batch advisories AWS-LC du 2026-06-11).
+# Dep optionnelle (feature aws-lc-rs, non utilisee par les builds ToM) heritee
+# de l upstream iroh-quinn - bump de securite, cf. FORK-GOVERNANCE.md.
+version = "0.41"
 optional = true
 
 [dependencies.bytes]


### PR DESCRIPTION
## Urgence CI

Le job `rust-security` (cargo-deny) est rouge sur les PR #41/#42/#43 depuis cet après-midi : **8 advisories AWS-LC publiées aujourd'hui même** (RUSTSEC-2026-0042→0048 + RUSTSEC-2025-0121) — PKCS7 verify bypass, CRL distribution point, name constraints wildcard/Unicode, timing side-channel AES-CCM. Le gate fait exactement ce pour quoi il a été posé au chantier S0.5 : toute nouvelle advisory casse la CI.

## Changements

| Crate | Avant | Après |
|---|---|---|
| aws-lc-rs | 1.16.0 | 1.17.0 |
| aws-lc-sys | 0.37.1 **et** 0.34.0 | 0.41.0 (unique) |
| aws-lc-fips-sys | 0.13.11 | 0.13.14 |

- L'entrée 0.34.0 était épinglée par **notre fork tom-quinn** (`aws-lc-sys = "0.34.0"`, hérité d'iroh-quinn) → req bumpée à `"0.41"` avec commentaire FORK-GOVERNANCE. Dépendance **optionnelle** (feature `aws-lc-rs`), jamais activée par les builds ToM (backend rustls = ring chez nous) — exposition réelle nulle, mais le lock doit être sain.

## Limite de validation

Non reproductible en local (macOS : la résolution de graphe n'inclut pas le backend aws-lc, `cargo deny` local vert même base à jour). **La CI de cette PR est le verdict.** Gates locales : clippy workspace + 1216 tests verts, build tom-quinn ok.

## Ordre de merge conseillé

Merger **cette PR en premier** : elle débloque le job rust-security. Je rebaserai ensuite #41/#42/#43 dessus pour les repasser au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)