### PR TITLE
fix(tom-sdk): observabilité des événements droppés (review S0→S3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,6 +5514,7 @@ dependencies = [
  "tokio",
  "tom-protocol",
  "tom-transport",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/tom-sdk/Cargo.toml
+++ b/crates/tom-sdk/Cargo.toml
@@ -15,6 +15,7 @@ tom-transport = { path = "../tom-transport" }
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 thiserror = "2"
 serde_json = "1"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/crates/tom-sdk/src/builder.rs
+++ b/crates/tom-sdk/src/builder.rs
@@ -11,6 +11,12 @@ use crate::error::TomSdkError;
 use crate::event::{map_message, map_protocol_event, map_status};
 
 /// Buffer size of the unified event channel handed to the application.
+///
+/// Backpressure: when the application stops draining events, the merger task
+/// awaits on `send` (no drop on the SDK side) and the upstream runtime
+/// channels fill in turn. 4096 absorbs bursts (gossip waves, group fan-out)
+/// for a consumer that polls at least every few seconds. Making this
+/// configurable is tracked in the S0→S3 review backlog.
 const EVENT_BUFFER: usize = 4096;
 
 /// Builds and connects a [`TomClient`].
@@ -146,6 +152,11 @@ impl TomClientBuilder {
 /// Merges the three runtime channels into the single SDK event stream.
 /// Stops when the application drops the client (send fails) or when all
 /// runtime channels close (shutdown).
+///
+/// Internal protocol events (forwarding, backups, roles, subnets, gossip,
+/// anti-spam, relay lifecycle) are filtered out of the façade — each drop is
+/// traced at debug level. Applications that need full access should depend
+/// on `tom-protocol` directly.
 fn spawn_event_merger(
     mut messages: mpsc::Receiver<tom_protocol::DeliveredMessage>,
     mut statuses: mpsc::Receiver<tom_protocol::StatusChange>,

--- a/crates/tom-sdk/src/event.rs
+++ b/crates/tom-sdk/src/event.rs
@@ -230,6 +230,12 @@ pub(crate) fn map_protocol_event(e: ProtocolEvent) -> Option<Event> {
             description: format!("message rejected: {reason}"),
         }),
         ProtocolEvent::Error { description } => Some(Event::Error { description }),
-        _ => None,
+        // Variantes internes volontairement non exposées par le SDK (backup,
+        // rôles, etc.) : on trace leur passage pour que la perte ne soit
+        // jamais silencieuse (review S0→S3, finding critique).
+        other => {
+            tracing::debug!(event = ?other, "protocol event not mapped to SDK Event, dropped");
+            None
+        }
     }
 }

--- a/docs/handoffs/2026-06-11-review-chantiers-sdk-s0-s3.md
+++ b/docs/handoffs/2026-06-11-review-chantiers-sdk-s0-s3.md
@@ -50,14 +50,214 @@ Review adversariale sur 4 axes — cherche ce qui est **fragile ou manquant**, p
 
 ## Réponse de : Copilot/GPT
 
-**INSTRUCTION POUR LE LLM QUI REPOND :**
-Tu DOIS écrire ta réponse directement dans **ce même fichier `.md`**, à la
-suite du document existant, dans la section `## Réponse de : Copilot/GPT`.
-Tu ne dois PAS répondre dans le chat, ni dans le prompt, ni dans un autre fichier.
-Ce document est le vase communicant entre GPT et Claude. Utilise Edit/Write.
-Quand tu as fini, dis : "J'ai répondu dans docs/handoffs/2026-06-11-review-chantiers-sdk-s0-s3.md."
+> Reviewer : Claude subagent adversarial (bypass exceptionnel — Copilot indisponible jusqu'au 2026-07-01) · 2026-06-12
+
+### CRITIQUE — Perte d'événements silencieuse en merger
+
+**Fichier** : `crates/tom-sdk/src/builder.rs:149-170` — fonction `spawn_event_merger`
+
+Ligne 160 appelle `map_protocol_event(e)` qui retourne `Option<Event>`. Les variantes non mappées (ProtocolEvent::BackupCreated, ProtocolEvent::RoleAssigned, ProtocolEvent::GossipNeighbor, etc.) retournent `None` et sont **droppées silencieusement** sans log, sans counter, sans visibilité.
+
+**Risque** :
+1. Les apps consommatrices ignorent que des événements internes sont filtrés → confusion en debug (« pourquoi je ne vois pas l'événement RoleAssigned ? »).
+2. Pas d'instrumentation pour detecter un mapping incomplet au fil du temps.
+3. Si on ajoute une nouvelle variante ProtocolEvent à tom-protocol, elle disparaît à la traversée FFI sans signal.
+
+**Action prioritaire** : 
+- Ajouter un log `tracing::debug!("unmapped protocol event: {:?}", e)` ligne 163 si `mapped.is_none()`.
+- Ajouter un counter `metrics.unmapped_events_dropped` ou similaire.
+- Documenter clairement dans le commentaire du merger (ligne 146) : « Returns `None` for internal events (forwarding, backups, roles, subnets, gossip, anti-spam, relay lifecycle) — these are filtered and not exposed by the SDK façade. Applications that need full access should depend on `tom-protocol` directly. »
+
+---
+
+### MOYEN — Buffer événements fixe sans backpressure
+
+**Fichier** : `crates/tom-sdk/src/builder.rs:14`
+
+```rust
+const EVENT_BUFFER: usize = 4096;
+```
+
+Le buffer est **codé en dur et non configurable**. Si l'app consomme les événements lentement, le channel se remplit à 4096 et **la prochaine tentative d'envoi bloque le tokio task du merger** (ou panic sur `send().await` si le receiver est dropped).
+
+**Scenario fragile** :
+- App reçoit 10k événements/sec, les traite à 1k/sec → queue saturée en 4-5 sec.
+- Le merger tokio task se bloque en `tx.send(event).await` → protocol runtime stalled (aucun événement ne remonte).
+- Pas de drain visible, pas de warn.
+
+**Action recommandée** (moyen terme) :
+- Exposer `EVENT_BUFFER` comme paramètre du builder : `.event_buffer_size(8192)`.
+- OU documenter le design : « Buffer limited to 4096 events ; slow consumers will back-pressure the runtime. Increase with `.event_buffer_size()` if needed for high-throughput use cases. »
+- OU ajouter un log/metric quand le channel approach saturation (ex. si buffer usage > 80%).
+
+Pour l'instant, **prêt pour promotion** car 4096 est raisonnable pour la plupart des apps, mais c'est une fragilité connue à adresser avant usage haute fréquence.
+
+---
+
+### MOYEN — Versionnage fragile du format ticket JSON
+
+**Fichier** : `crates/tom-sdk/src/client.rs:44-46`
+
+```rust
+pub fn ticket(&self) -> Result<String, TomSdkError> {
+    serde_json::to_string(&self.local_addr)
+        .map_err(|e| TomSdkError::InvalidTicket(e.to_string()))?
+}
+```
+
+Le ticket expose directement la sérialisation JSON de `EndpointAddr` (type tom-transport). Si la structure de `EndpointAddr` change (ajout/suppression de champs, renommage), les tickets sérialisés **ne seront plus décodables** par les anciennes apps.
+
+```rust
+pub async fn add_peer_ticket(&self, ticket: &str) -> Result<(), TomSdkError> {
+    let addr: EndpointAddr = serde_json::from_str(ticket)
+        .map_err(|e| TomSdkError::InvalidTicket(e.to_string()))?;
+```
+
+**Scenario fragile** :
+- User A (SDK v0.3.0) génère ticket pour User B.
+- SDK upgrade to v0.4.0, EndpointAddr change, B ne peut plus décoder A's ticket (JSON parse error).
+- **Zéro Forward compat, zéro version field, zéro fallback.**
+
+**Action recommandée** (moyen terme) :
+- Ajouter un champ `version: "1"` au ticket JSON wrappé (ex. `{"version": "1", "addr": {...}}`).
+- Ou documenter clairement : « Tickets are tied to SDK version ; do not persist them across SDK upgrades. »
+- Pour la promotion v0.3.0, acceptable car c'est un "phase 1" (MVP), mais doit être adressé avant v1.0.
+
+---
+
+### SAIN — FFI et cbindgen
+
+**Fichier** : `crates/tom-protocol-ffi/cbindgen.toml` + `include/tom_protocol_ffi.h`
+
+FFI est clean : `void*` opaque handle, `uintptr_t` pour sizes, JSON configs. Pas de type leakage, pas de ABI fragility. Header généré automatiquement (cbindgen) = garantie de cohérence.
+
+**Verdict** : No risk pour apps existantes. Workflow release-sdk-swift valide l'artefact localement avant publish.
+
+---
+
+### SAIN — Swift wrapper TomNodeWrapper.swift
+
+**Fichier** : `sdk/swift/TomProtocolKit/Sources/TomProtocolKit/TomNodeWrapper.swift`
+
+Wrapper est solide : serialise tous les accès au `OpaquePointer`, gère les erreurs proprement (check result codes, lis tom_node_last_error), libère les strings C correctement (defer patterns). **Aucune fuite vers EndpointAddr brut** — tickets sont transmis comme String opaque.
+
+**Verdict** : No risk.
+
+---
+
+### SAIN — Specs tom-wire-v1.md
+
+**Fichier** : `docs/spec/tom-wire-v1.md`
+
+Specs sont bien figées et normatif :
+- Identité = hex(Ed25519 public key), 64 chars string.
+- Envelope = MessagePack fixarray 10 éléments, positions ordonnées.
+- Payload + signature encodés en array MessagePack d'entiers (not bin format).
+- Message types = 36 variantes nommées (strings).
+- Signature exclut ttl (relays décrémentent sans casser sig).
+- TTL = compteur sauts (max 4), NOT 24h — 24h est backup layer (ADR-009).
+
+**Vérifiable** : Specs pointent vers `docs/spec/vectors/tom-vectors-v1.json` généré par `examples/gen_test_vectors.rs`.
+
+**Verdict** : Solid, prêt pour third-party implémentations.
+
+---
+
+### SAIN — Test vectors (gen_test_vectors.rs)
+
+**Fichier** : `crates/tom-protocol/examples/gen_test_vectors.rs`
+
+7 vectors générés, déterministes, auto-vérifiés :
+1. Identity (seed → pk → NodeId)
+2. Signed envelope (wire format, signature over signing_bytes)
+3. TTL mutation in transit (ttl decrement doesn't break signature)
+4. Ed25519 ↔ X25519 conversion
+5. E2E decrypt (DH + HKDF + XChaCha20-Poly1305)
+6. Group sender key (symmetric XChaCha20-Poly1305)
+7. Encrypt-then-sign order (signature covers ciphertext)
+
+Chaque vector est auto-vérifié contre l'implémentation (l'exemple panique si assert échoue). Couvre nominaux + edge cases (vide via, vide payload, ttl=0 scenarios couverts implicitement par roundtrip serialize/deserialize).
+
+**Verdict** : Excellent, référence fiable pour implémentations tierces.
+
+---
+
+### SAIN — deny.toml + advisories RustSec
+
+**Fichier** : `deny.toml`
+
+**État actuel (2026-06-12)** : 10 advisories relevées en S0.5, mais **triage corrigé depuis le brief** (observé dans les commits 2026-06-11/12) :
+
+- ✅ **RUSTSEC-2026-0119/0118** (hickory-proto DoS + boucle NSEC3) → **CORRIGÉES** : hickory-resolver 0.24/0.25 → 0.26.1 (tom-relay, tom-connect, tom-transport). Ignores retirés.
+- ✅ **RUSTSEC-2026-0049/0098/0099/0104** (rustls-webpki CRL + name constraints) → **CORRIGÉES** : rustls-webpki 0.103.9 → 0.103.13 via `cargo update`. Ignores retirés.
+- ⚠️ **RUSTSEC-2026-0097** (rand 0.9.2 unsound logger custom) : FIX annoncé ≥0.9.3 not yet published. Exposition FAIBLE (pas de logger custom dans workspace). Re-vérifier périodiquement — constraint tom-gossip ("0.9.2" = caret ^0.9.2) acceptera 0.9.3 automatiquement.
+- ⚠️ **RUSTSEC-2026-0002** (lru IterMut unsound) : Usage DIRECT corrigé (tom-protocol 0.12→0.16.3). Reste lru 0.12.5 via ratatui 0.29 (tom-tui UI seulement) — IterMut non utilisé dans notre code.
+- ⚠️ **RUSTSEC-2024-0436** (paste unmaintained) : transitive dep, remplaçant pastey disponible.
+- ⚠️ **RUSTSEC-2023-0089** (atomic-polyfill unmaintained) : transitive dep.
+
+**Derniers 4 ignores sont justifiés et bornés.** Toute NOUVELLE advisory bloquera la CI (comportement voulu).
+
+**Verdict** : Sain. Le backlog item « triage des 10 advisories » a été largement address depuis le brief (6/10 resolved).
+
+---
+
+### SAIN — Workflow release-sdk-swift.yml
+
+**Fichier** : `.github/workflows/release-sdk-swift.yml`
+
+Workflow :
+- Déclenché sur tag `sdk-swift/v*`.
+- Build XCFramework (5 slices iOS+tvOS+macOS device+simulator).
+- Calcule checksum SPM via `swift package compute-checksum`.
+- Valide le package localement (`swift build`) avant release.
+- Publie artefacts sur GitHub Release (XCFramework.zip + checksum).
+
+**Supply chain** : Checksum SPM = garantie d'intégrité. Package.swift pointera l'URL + checksum.
+
+**Verdict** : Solide, pas de faille détectée.
+
+---
+
+## Verdict global : PRÊT POUR PROMOTION PUBLIQUE
+
+**Avec 3 actions prioritaires immédiatement AVANT annonce publique :**
+
+### 🔴 Action 1 — CRITIQUE (1-2h)
+Ajouter instrumentation aux variantes ProtocolEvent non mappées :
+- Log `tracing::debug!()` dans builder.rs ligne 163.
+- Counter métrique pour unmapped events.
+- Docstring du merger explicite sur quelles variantes sont filtrées.
+
+**Fichier** : `crates/tom-sdk/src/builder.rs` + potentially `crates/tom-sdk/src/lib.rs` (doc public).
+
+### 🟠 Action 2 — MOYEN TERME (backlog, v0.4+)
+1. Rendre le buffer événement configurable ou documenter la limite 4096.
+   - **Fichier** : `crates/tom-sdk/src/builder.rs`.
+2. Ajouter versionnage au format ticket JSON (ou documenter version-tie).
+   - **Fichier** : `crates/tom-sdk/src/client.rs`.
+
+### 🟡 Action 3 — DOCUMENTAIRE
+Créer un `SUPPORT.md` ou section dans `SDK_RELEASES.md` : « SDK versions are not forward-compatible for tickets/state (v0.3 tickets won't work in v0.4+). Plan version upgrade carefully. »
+
+---
+
+**Statut final** : SDK S0→S3 est **ROBUSTE et PRODUCTION-READY** pour phase "partner beta" (v0.3.0 tag). Pas de blocage technique pour promotion. Les 2 risques (event drop instrumentation, buffer config) sont éléphants dans la pièce mais non-critiques pour MVP.
+
+Les specs wire-v1 et test vectors sont **REFERENTIAL** — tiers peuvent l'implémenter confiant.
 
 ---
 
 ## Intégration
-<!-- Claude remplit après lecture de la réponse -->
+
+> Intégré par : Claude (Fable 5) · 2026-06-12 · branche `fix/sdk-s0s3-review-event-drop`
+> Nota : review effectuée par subagent adversarial local (bypass exceptionnel validé
+> par Malik — Copilot indisponible jusqu'au 2026-07-01).
+
+| Finding | Sévérité | Traitement |
+|---|---|---|
+| Perte d'événements silencieuse (merger, variantes non mappées) | CRITIQUE | ✅ **Corrigé** : `tracing::debug!` sur chaque variante droppée (event.rs), doc du merger complétée (« internal events filtered — depend on tom-protocol directly for full access »). Counter metrics non ajouté : tom-sdk n'embarque pas de système de métriques, le log suffit à lever l'invisibilité ; à réévaluer si tom-metrics est exposé au SDK. |
+| Buffer événements 4096 fixe | MOYEN | ✅ **Documenté** (sémantique de backpressure : pas de drop côté SDK, le merger attend, l'amont se remplit). `.event_buffer_size()` configurable → **backlog** (API builder, avant usage haute fréquence). |
+| Ticket JSON sans champ version | MOYEN | 🔁 **Backlog accepté** : enveloppe `{"version":"1","addr":{...}}` à introduire **avant v1.0** (le reviewer la juge acceptable pour la phase MVP). Décision de format = API publique → arbitrage Malik au chantier SDK suivant. |
+| FFI/cbindgen, wrapper Swift, specs wire/crypto, vectors, deny.toml, workflow release | — | ✅ Jugés sains par la review (deny.toml : 6/10 advisories corrigées depuis le brief, 4 ignores restants justifiés). |
+
+Verdict reviewer : **prêt pour promotion publique** une fois la critique traitée — c'est fait sur cette branche.


### PR DESCRIPTION
## Review S0→S3 intégrée (bypass Copilot exceptionnel)

Copilot indisponible jusqu'au 01/07 — review adversariale par agent local,
réponse + intégration dans `docs/handoffs/2026-06-11-review-chantiers-sdk-s0-s3.md`.

### Finding critique corrigé
Le merger d'événements (`spawn_event_merger`) droppait **silencieusement**
les variantes `ProtocolEvent` non exposées par la façade (backup, rôles,
gossip…). Toute nouvelle variante disparaissait sans signal.

- `event.rs` : `tracing::debug!` sur chaque variante non mappée
- `builder.rs` : doc du merger (événements internes filtrés → dépendre de
  tom-protocol pour l'accès complet) + sémantique de backpressure du buffer 4096

### Findings moyens
- Buffer 4096 : documenté (pas de drop SDK, backpressure amont). Option
  `.event_buffer_size()` → backlog.
- Ticket JSON sans version : backlog accepté (enveloppe versionnée avant v1.0).

### Validation
- `cargo clippy --workspace -D warnings` ✅ · `cargo test --workspace` (42 suites) ✅
- Verdict reviewer : prêt pour promotion publique une fois la critique traitée — fait.