### PR TITLE
docs(audit): état des lieux complet du codebase ToM (audit 6 agents)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,14 +93,19 @@ All critical iroh dependencies have been forked under the `tom-*` namespace (MIT
 - `iroh-quinn-udp` — netwatch exposes its types in public API, forking creates type mismatch
 - `n0-error`, `n0-future`, `n0-watcher` — general-purpose utils, shared with external deps
 
-### Wire Invariants (NEVER change)
+### Wire Invariants (état réel — vérifié 2026-06-26)
 
-These are baked into the protocol and must stay compatible with iroh network:
-- `_iroh` DNS prefix (Pkarr/discovery)
-- `.iroh.invalid` TLS SNI
-- `X-Iroh-*` HTTP headers (relay protocol)
-- `b"/iroh-qad/0"` ALPN
-- `iroh.link` relay URLs
+⚠️ Les identifiants protocolaires ont été **migrés vers le namespace `tom-*`**. Conséquence : ToM n'est **PAS** wire-compatible avec le réseau iroh public (un nœud iroh ne peut pas parler à un nœud/relais ToM, et inversement). C'est volontaire (souveraineté du protocole), mais à ne PAS casser entre versions ToM :
+
+| Invariant | Valeur réelle | Fichier:ligne |
+|-----------|---------------|---------------|
+| DNS record prefix | `_tom` | `tom-relay/src/endpoint_info.rs:739` |
+| TLS SNI | `.tom.invalid` | `tom-connect/src/tls/name.rs:19` |
+| HTTP headers (relay) | `X-Tom-*` (`X-Tom-NodeId`, `X-Tom-Challenge`, `X-Tom-Response`) | `tom-relay/src/main.rs:35`, `server.rs:59` |
+| ALPN transport | `b"tom-protocol/transport/0"` | `tom-transport/src/lib.rs:116` |
+| ALPN gossip | `b"/tom-gossip/1"` | `tom-gossip/src/net.rs:46` |
+
+**Restent en dur sur l'infra iroh/n0 (services externes, actifs seulement avec le preset `n0_discovery`)** — PAS des invariants ToM, remplaçables : `dns.iroh.link` (`tom-relay/src/dns.rs:32`), `https://dns.iroh.link/pkarr` (`tom-connect/src/address_lookup/pkarr.rs:126`), `*.iroh-canary.iroh.link` (`tom-connect/src/endpoint.rs:1412`).
 
 ### Cargo Alias Trick
 
@@ -451,7 +456,7 @@ Trous **confirmés** (review multi-agent, file:line). À traiter par phases ; ne
 4. **Roles are network-assigned**: Nodes don't choose to be relays
 5. **No blockchain**: This is a transport protocol, not a ledger
 6. **Contribution matters**: Usage/contribution score affects role assignment
-7. **Wire invariants are sacred**: Never change `_iroh` prefixes, ALPN, TLS SNI
+7. **Wire invariants are sacred**: NE PAS changer les identifiants `tom-*` (préfixe DNS `_tom`, SNI `.tom.invalid`, en-têtes `X-Tom-*`, ALPN `tom-protocol/transport/0` et `/tom-gossip/1`) entre versions ToM. ⚠️ ToM n'est PAS compatible iroh (voir « Wire Invariants »).
 8. **ed25519-dalek pin**: MUST use `=3.0.0-pre.1` (crypto type compat with quinn)
 9. **Signaling server is DEPRECATED**: Use own relay + Pkarr/DNS
 10. **FFI validation before push**: `tom-protocol-ffi` is excluded from the workspace (built `--locked`). `cargo test/clippy --workspace` does NOT cover it. Run `bash scripts/check-ffi.sh` — or build from a clean `git worktree` at HEAD — before any push touching the FFI/cross-crate. The working copy masks committed-state compile errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ UDP (iroh-quinn-udp)               ← Raw UDP I/O (not forked — netwatch comp
 
 ### Fork Status
 
+> **Indépendance (à retenir)** : ToM est **né d'un fork d'iroh 0.96**, mais le protocole est désormais **autonome et souverain**. Tous les identifiants de protocole (DNS `_tom`, SNI `.tom.invalid`, en-têtes `X-Tom-*`, ALPN `tom-*`) sont sous notre namespace. Conséquence assumée : **ToM n'est PAS — et n'a pas vocation à rester — wire-compatible avec le réseau iroh public.** iroh est notre *point de départ historique*, pas une dépendance réseau. Les seuls résidus iroh sont des hostnames de services externes n0 (`dns.iroh.link`), actifs uniquement avec le preset `n0_discovery`, et remplaçables.
+
 All critical iroh dependencies have been forked under the `tom-*` namespace (MIT license):
 
 | Original | Fork | LOC | Notes |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -1,0 +1,256 @@
+# 🎯 MISSION — ToM Protocol : atteindre la cible finale
+
+> Document maître. Lu en premier par tout agent (Claude Code / Fable 5) qui reprend le projet.
+> Rédigé 2026-06-26. Ne PAS diluer la cible. Si un choix s'éloigne de la cible → il est refusé.
+> Sources : `_bmad-output/planning-artifacts/product-brief-tom-protocol-2026-01-30.md`, `CLAUDE.md` (7 verrous), `docs/audits/AUDIT-2026-06-26.md`.
+
+---
+
+## 0. Comment lire ce document
+
+1. **§1 = LA CIBLE.** Non négociable. C'est le nord. Tout le reste sert §1.
+2. **§2 = les formes de livraison** (SDK + au-delà).
+3. **§3 = où on en est** (état réel, audit).
+4. **§4 = comment tu travailles** (agents, skills, journal, boucle, tests durs, auto-critique).
+5. **§5 = « cible atteinte » = quoi exactement** (Definition of Done mesurable).
+6. **§6 = garde-fous** (les 7 verrous, ne pas changer de cap).
+
+---
+
+## 1. LA CIBLE FINALE (détail complet — à ne jamais oublier)
+
+**ToM (The Open Messaging) est une COUCHE DE TRANSPORT universelle — comme TCP/IP — pas une application.** Elle transporte des octets de A à B, librement, sans permission, sans serveur, sans péage, sans trace. *(brief l.14, l.60)*
+
+La cible est atteinte quand le réseau possède **simultanément** toutes ces propriétés :
+
+### 1.1 Réseau complètement distribué — chacun sa part de travail
+- **L'infrastructure, ce sont les utilisateurs.** Aucun serveur, aucun serveur fédéré, aucun relais bénévole, aucun nœud de bootstrap contrôlé par une entité unique. *(brief l.54, l.66)*
+- Tout appareil avec CPU + connectivité + un minimum de stockage devient un nœud : smartphone, box internet, routeur, TV, terminal de paiement, objet connecté. *(brief l.50)*
+- **Utiliser = contribuer.** Participation automatique et invisible. Pas d'opt-in, pas de « merci de seeder ». *(brief l.53)*
+
+### 1.2 Rôle NON choisi — assigné par le besoin du réseau
+- Les rôles (client, relais, hub, backup…) sont **imposés dynamiquement et de façon imprévisible**, au dernier moment, en fonction du **besoin du réseau** et de la **capacité de l'appareil** — jamais choisis par l'utilisateur. *(brief l.65, verrou #3, ADR-006)*
+- Impossible à truquer : on ne peut pas décider d'être relais ni d'y échapper.
+
+### 1.3 Indébranchable — propagation « virus » proportionnelle à la demande
+- **Plus il y a de demande, plus l'effort se propage** à travers le réseau, **sans pouvoir être arrêté ni débranché.** Couper un nœud ne coupe rien : les messages se re-routent, les rôles se réassignent. *(brief l.194, ADR-009)*
+- **Métaphore virus (backup)** : les messages pour destinataires hors-ligne **se répliquent** sur des nœuds de secours, puis **s'auto-détruisent** à la livraison ou après TTL. Résilience par réplication, pas par centralisation. *(ADR-009)*
+- **Aucun point de coupure = aucun point de contrôle.** C'est le cœur politique du projet. *(brief l.24, l.33)*
+
+### 1.4 Toujours chiffré (E2E obligatoire)
+- **Toutes** les données sont chiffrées de bout en bout. Aucun nœud de la chaîne ne peut lire le contenu. *(brief l.172, ADR-004)*
+- Stack : Ed25519 (signature) + X25519 (DH) + XChaCha20-Poly1305 (AEAD) + HKDF-SHA256. Encrypt-then-sign. *(ADR-004)*
+
+### 1.5 Purge par défaut — le réseau oublie
+- **Message livré = message supprimé.** L'état passé est compacté puis effacé. TTL 24h max, purge globale sans exception. Le réseau reste léger quel que soit son âge. *(brief l.55, verrou #2, ADR-002)*
+- **Livraison = ACK du destinataire final.** Un message est livré ⟺ le destinataire émet un ACK (signé). *(verrou #1)*
+
+### 1.6 Invisible & multi-plateforme
+- **Intégration invisible** : livré comme couche SDK/protocole. L'utilisateur ouvre son app, ça marche. Zéro config, zéro friction. Personne ne sait qu'il utilise ToM — et c'est pour ça que ça marche. *(brief l.56, l.146, verrou #6)*
+- **Multi-plateforme par nature** : navigateur (WASM), iOS/tvOS/macOS, Android, Linux/Windows, IoT/routeurs/embarqué. Un cœur, des bindings partout.
+
+### 1.7 Économie non spéculative
+- Équilibre interne contribution/usage. **Pas de token, pas de frais, pas de blockchain, pas d'actif convertible.** Le score n'est pas un actif : c'est une mesure d'équilibre. *(brief l.67, verrou #4/#5)*
+- **Rien à voler** : pas de token, pas de datastore central. Attaquer ToM ne rapporte rien. *(brief l.58)*
+
+### 1.8 Souverain & libre
+- **N'appartient à personne.** Open source radical, n'évolue que par la communauté. Né d'un fork d'iroh 0.96 mais **autonome et souverain** (namespace `tom-*`, PAS compatible iroh — assumé). *(CLAUDE.md Fork Status, brief l.14, l.69)*
+- **Proposé gratuitement**, sous la forme la plus pertinente et la plus accessible possible.
+
+> **Résumé en une phrase** : un bus de données planétaire, chiffré, distribué sur les appareils des gens, où les rôles s'imposent selon le besoin, qui se propage comme un virus proportionnellement à la demande, qu'on ne peut ni arrêter ni débrancher, qui oublie ce qu'il a livré, et que personne ne possède.
+
+---
+
+## 2. FORMES DE LIVRAISON (SDK + au-delà — on peut TOUT faire)
+
+La cible impose « la forme la plus pertinente et accessible ». Ce n'est **pas un choix unique** : on multiplie les portes d'entrée. Priorité au SDK, mais tout ce qui augmente l'accessibilité est légitime.
+
+| Forme | Cible d'intégrateur | Base existante | Priorité |
+|---|---|---|---|
+| **SDK cœur Rust** (`tom-sdk`) | Toute app native | `crates/tom-sdk` existe | 🥇 P0 |
+| **Binding Swift** (iOS/tvOS/macOS) | Apps Apple | `tom-protocol-ffi` + XCFramework CI | 🥇 P0 |
+| **Binding WASM/JS** (navigateur + Node) | Web, sans install | packages TS legacy à moderniser | 🥇 P0 |
+| **Binding Kotlin/JNI** (Android) | Apps Android | à créer via FFI | 🥈 P1 |
+| **Binding Python** | Backends, prototypage, IoT | à créer via FFI | 🥈 P1 |
+| **Extension navigateur** (nœud persistant, cadenas bleu) | Utilisateur final web | roadmap brief l.201 | 🥈 P1 |
+| **Daemon / CLI** (`tom-tui`, `tom-node`) | Serveurs, power users, tests | `tom-tui` existe | 🥈 P1 |
+| **Module embarqué / routeur / box** | IoT, Freebox | `tom-gateway` (Freebox) existe | 🥉 P2 |
+| **App de référence** (chat démo multi-plateforme) | Preuve vivante, adoption | apps tvOS existantes | 🥉 P2 |
+| **Spécification publique** (`docs/spec/`) | Ré-implémenteurs tiers | `tom-wire-v1`, `tom-crypto-v1` existent | 🥈 P1 |
+| **Packages publiés** (crates.io, npm, SPM, Maven, PyPI) | Distribution zéro-friction | à faire | 🥈 P1 |
+
+> Règle : chaque nouvelle forme **doit réutiliser le cœur Rust unique** (un seul protocole, N façades). Jamais de ré-implémentation divergente du protocole par plateforme.
+
+**Si tu identifies une meilleure forme d'accessibilité, propose-la** dans le journal (§4.3) — on ne se limite pas à cette liste.
+
+---
+
+## 3. OÙ ON EN EST (point de départ — audit 2026-06-26)
+
+Réf. complète : `docs/audits/AUDIT-2026-06-26.md`. Résumé :
+
+- ✅ **Cap verrouillé** : 7 verrous → **5 ✅, 1 ⚠️ (#2), 1 ❌ (#1)**. Les écarts sont des **bugs localisés**, pas des dérives de conception.
+- 🟢 **Solide** : crypto E2E, transport/NAT (holepunch 100 % terrain), relais stateless.
+- 🔴 **Bugs à fermer en priorité** (déjà localisés, `fichier:ligne` dans l'audit) :
+  1. **ACK entrant non vérifié** (verrou #1) — `state.rs:872`.
+  2. **Purge SQLite hub jamais déclenchée** (verrou #2) — `state.rs:536`.
+  3. **Failover hub mort au runtime** — `manager.rs:846,880`.
+  4. **Split-brain / hub hijack** — `manager.rs:449-465`.
+  5. **Double-version `ed25519-dalek`** ; **pre-push-gate ignore Rust** ; **tom-connect/dht/integration absents de CI**.
+- 🚧 **Manque pour un test réel hors-domicile** (voir aussi `docs/plans/2026-03-30-organic-seed-handoff-test.md`) : découverte zéro-infra validée avec un inconnu, client installable par un non-dev, relais public non-perso.
+
+**La cible n'est pas atteinte. Ne jamais prétendre « complete ».**
+
+---
+
+## 4. COMMENT TU TRAVAILLES (protocole opératoire de l'agent)
+
+### 4.1 Agents à gogo (orchestration massive)
+- **Par défaut, délègue.** Utilise le tool `Workflow` pour orchestrer des flottes d'agents (fan-out → vérifie → synthétise) et le tool `Agent` pour les sous-tâches isolées.
+- Patterns imposés selon la tâche :
+  - **Explorer** (`Explore`) pour cartographier avant de coder.
+  - **Planifier** (`Plan`) avant tout changement > 1 fichier.
+  - **Fan-out par dimension** (bugs / perf / sécurité / conformité verrous) puis **vérification adverse** (plusieurs sceptiques qui tentent de RÉFUTER chaque trouvaille ; on ne garde que ce qui survit au vote majoritaire).
+  - **Loop-until-dry** pour la découverte de bugs/edge-cases : on relance des chercheurs jusqu'à 2 tours consécutifs sans rien de neuf.
+- **Isolation `worktree`** dès que plusieurs agents modifient des fichiers en parallèle.
+- Règle d'or : *un agent produit de la donnée vérifiée, pas une opinion.* Toujours `fichier:ligne`. Zéro hallucination (CLAUDE.md §5).
+
+### 4.2 Skills pour se perfectionner
+Utilise les skills disponibles comme multiplicateurs de qualité, pas comme décoration :
+- `/code-review` (correctness + reuse) et `/simplify` (nettoyage) sur chaque diff.
+- `/angle-mort` (review anti-complaisance : cherche le fragile, le manquant, le faux-confort — ne félicite pas).
+- `/verify` et `/run` pour prouver qu'un changement marche pour de vrai (pas seulement les tests).
+- `/security-review` avant tout push touchant crypto/réseau.
+- `/review-copilot` + `docs/handoffs/` pour handoff inter-LLM (CLAUDE.md §25).
+- Les agents BMAD (`bmad-*`) pour architecture, stories, retrospectives quand on ouvre un gros chantier.
+- `/deep-research` quand une décision dépend d'un état de l'art externe.
+
+> Avant une tâche : demande-toi « quel skill rendrait ce rendu meilleur ? » et utilise-le.
+
+### 4.3 Journal — note TOUT (pour reprendre + expliquer)
+Tenue obligatoire d'un journal, pour que n'importe qui (humain ou agent) reprenne sans contexte perdu :
+- **`docs/journal/JOURNAL.md`** — registre append-only. Une entrée par session/chantier :
+  ```
+  ## [YYYY-MM-DD HH:MM | MODEL-ID] — <titre du chantier>
+  ### Objectif (lien vers la propriété §1 visée)
+  ### Ce que j'ai fait (décisions + POURQUOI, pas seulement quoi)
+  ### Fichiers touchés (chemin:ligne)
+  ### Résultats de tests (chiffres réels, liens vers rapports)
+  ### Ce qui reste / prochain [→]
+  ### Auto-critique (ce qui est fragile, ce dont je doute)
+  ```
+- **Explique ce que tu fais** en continu : chaque décision non triviale est justifiée dans le journal.
+- Les todos survivent aux compactions (CLAUDE.md §17). Reprise = dernier `[→]` ou premier `[ ]`.
+- Tout chantier qui finit un objectif → entrée de journal + mise à jour de la **checklist §5**.
+
+### 4.4 Boucle « itérer jusqu'à la cible » (mode réitération)
+C'est le mode de fonctionnement par défaut. Pour chaque objectif tiré de §1 :
+
+```
+1. DÉFINIR l'état-cible mesurable (un critère de §5).
+2. MESURER l'écart réel (agents d'exploration + tests). Chiffrer.
+3. PLANIFIER le minimum viable qui réduit l'écart (skill /Plan).
+4. IMPLÉMENTER (Edit ciblé, jamais réécriture si >20 lignes intactes).
+5. TESTER DUR (§4.5) + simuler la prod.
+6. DOCUMENTER les résultats obtenus (journal + rapport de test).
+7. AUTO-CRITIQUE (skill /angle-mort) : qu'est-ce qui casse encore ?
+8. SI critère non atteint → retour 2 avec les nouveaux constats.
+   SI atteint → cocher §5, entrée journal, objectif suivant.
+```
+
+- Pour l'exécution récurrente/non-supervisée, tu peux utiliser le skill `/loop` (réitère un objectif à intervalle jusqu'à la condition de sortie).
+- **Condition d'arrêt d'un objectif = son critère §5 vérifié par un test reproductible**, pas « ça a l'air bon ».
+- **Ne jamais élargir le scope en douce.** Une itération = un pas vers un verrou de §1.
+
+### 4.5 Tests DURS — couvrir l'entièreté des fonctions
+Objectif : **couvrir l'intégralité des fonctions**, pas « valider l'algo heureux ». Chaque fonction publique + chaque chemin d'erreur.
+
+Taxonomie imposée (documente chaque catégorie) :
+1. **Unitaires isolés** : chaque fonction testée seule, y compris branches d'erreur, entrées limites, valeurs nulles/max, unicode, tailles extrêmes.
+2. **Property-based** (proptest) : invariants (ex : `decrypt(encrypt(x)) == x`, `signing_bytes` stable, dedup idempotent). Génère des milliers de cas.
+3. **Adversariaux / sécurité** : nonce rejoué, ACK forgé, signature malléable, slot DHT squatté, hub usurpé, message expiré, TTL dépassé. Le test **doit prouver le rejet**.
+4. **Fuzzing** du wire format (envelope MessagePack) et du handshake.
+5. **Simulation de mise en production (chaos)** : multi-nœuds réels, NAT symétrique, CGNAT, churn (nœuds qui entrent/sortent), blackout réseau puis récupération, partition, isolation → reconvergence. Réutilise/étends `tom-stress` et `tom-integration-tests`.
+6. **Parties isolées en conditions réelles** : chaque crate testable seule ET en intégration ascendante (tom-connect → tom-transport → tom-protocol → tom-sdk).
+7. **Multi-plateforme** : FFI (`bash scripts/check-ffi.sh`), WASM, bindings — un chemin de test par façade.
+8. **Non-régression des 7 verrous** : une suite dédiée qui échoue si un verrou est violé (ex : un message livré non purgé, un ACK non signé accepté, un ban permanent, un rôle choisi manuellement).
+
+Règles :
+- **Coverage visé : maximal et mesuré** (ajouter `cargo llvm-cov` en CI). Documenter le % réel, jamais l'inventer.
+- Un bug trouvé → d'abord un **test qui échoue** le reproduit, ensuite le fix.
+- **Documenter ce que les tests révèlent** dans `docs/test-reports/AAAA-MM-JJ-<sujet>.md` : ce qui passe, ce qui casse, les chiffres, les surprises.
+- **Se remettre en question** : si un test passe trop facilement, il est probablement faible → durcis-le (skill `/angle-mort`).
+
+### 4.6 Gate avant push (non négociable, CLAUDE.md §24)
+```bash
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+bash scripts/check-ffi.sh          # FFI hors workspace
+```
+Jamais `--no-verify`. Si rouge → corriger avant push. Commits atomiques, messages français, **jamais** signer.
+
+---
+
+## 5. « CIBLE ATTEINTE » = QUOI EXACTEMENT (Definition of Done mesurable)
+
+La cible §1 est atteinte quand **tous** ces critères sont vérifiés par un test/démo reproductible. Coche uniquement avec preuve (`fichier:ligne` ou rapport).
+
+### Conformité protocole (les 7 verrous)
+- [ ] **#1** Un message est marqué livré **⟺** ACK signé du destinataire vérifié (ACK forgé rejeté). *(auj. ❌)*
+- [ ] **#2** Tout message livré/expiré est purgé partout ≤ TTL 24h — y compris `hub_message_history` SQLite. *(auj. ⚠️)*
+- [ ] **#3** Aucun nœud (relais/L1) n'arbitre ; pass-through pur. *(auj. ✅ — garder)*
+- [ ] **#4** Réputation en fade progressif, aucun ban permanent, rejoin immédiat. *(auj. ✅)*
+- [ ] **#5** Anti-spam progressif, jamais exclusion binaire. *(auj. ✅)*
+- [ ] **#6** Zéro état protocolaire visible par l'utilisateur final. *(auj. ✅)*
+- [ ] **#7** Aucune logique produit dans le transport ; transport d'octets pur. *(auj. ✅)*
+
+### Résilience « virus / indébranchable »
+- [ ] Couper N-1 nœuds sur N ne perd aucun message (re-route + backup virus prouvés).
+- [ ] Rôle réassigné automatiquement à la perte d'un hub (failover réel au runtime, pas seulement en test). *(bloqué par bug #3)*
+- [ ] Isolation totale d'un nœud → reconvergence automatique au retour.
+- [ ] Charge ↑ → propagation de l'effort mesurée (plus de demande = plus de nœuds mobilisés).
+
+### Réseau réellement distribué & zéro-config
+- [ ] Deux inconnus, sur deux réseaux différents, **sans aucune infra perso hardcodée**, échangent un message chiffré (découverte via DHT rendezvous + Pkarr uniquement).
+- [ ] Aucun nœud privilégié, aucun bootstrap contrôlé indispensable.
+
+### Livraison / accessibilité (formes §2)
+- [ ] SDK Rust `tom-sdk` documenté + testé + publiable (crates.io).
+- [ ] Au moins un binding non-Rust intégrable en < 30 min par un dev tiers (Swift **et** WASM/JS visés).
+- [ ] Un non-développeur peut installer un client et rejoindre (TestFlight / paquet signé / page web).
+- [ ] Spec publique à jour permettant une ré-implémentation indépendante.
+
+### Multi-plateforme & chiffrement
+- [ ] Le même protocole tourne et interopère sur ≥ 3 familles de plateformes (Apple, navigateur/WASM, Linux ; Android en cible).
+- [ ] 100 % du trafic E2E ; vecteurs de test crypto à jour et verts.
+
+### Qualité
+- [ ] Toutes les fonctions publiques couvertes ; suite de non-régression des 7 verrous verte.
+- [ ] Simulation de prod (chaos/churn/NAT/blackout) documentée et stable.
+- [ ] CI couvre tous les crates (dont tom-connect, tom-dht, integration, FFI, WASM) ; coverage mesuré.
+
+> Tant qu'une case reste vide, la mission continue. Le journal (§4.3) trace la progression.
+
+---
+
+## 6. GARDE-FOUS (ne pas changer de cap)
+
+1. **§1 prime tout.** Une feature qui ne sert pas une propriété de §1 est refusée.
+2. **Anti-hallucination absolu** (CLAUDE.md §5) : jamais inventer un fait/API/chiffre. Incertain → « je ne peux pas l'affirmer » + hypothèses + comment vérifier.
+3. **Wire invariants `tom-*` sacrés** entre versions ToM (préfixe DNS `_tom`, SNI `.tom.invalid`, `X-Tom-*`, ALPN `tom-protocol/transport/0` et `/tom-gossip/1`). ToM n'est PAS compatible iroh — assumé.
+4. **Jamais de** : serveur central, token/blockchain, ban permanent, rôle choisi manuellement, persistance au-delà du TTL, état protocolaire visible. Chacun viole un verrou.
+5. **Doc = code.** Si un écart doc/réalité est trouvé, corriger la doc immédiatement (comme fait pour les wire invariants le 2026-06-26).
+6. **Un chantier n'est PAS fini** tant que clippy + test workspace + FFI ne passent pas et que le critère §5 visé n'est pas coché avec preuve.
+
+---
+
+## 7. Premier pas recommandé pour l'agent qui reprend
+
+1. Lire ce fichier, puis `docs/audits/AUDIT-2026-06-26.md`.
+2. Créer `docs/journal/JOURNAL.md` (première entrée : reprise).
+3. Ouvrir le chantier **« fermer les 2 bugs de verrous »** (#1 ACK entrant, #2 purge SQLite) — effort faible/trivial, fait passer 2 verrous au vert. Écrire d'abord les tests qui échouent (verrou #1 : ACK forgé doit être rejeté ; verrou #2 : table purgée ≤ TTL).
+4. Puis chantier **failover hub réel** (#3), puis **anti-squat DHT** + **CI/coverage complète**.
+5. En parallèle (agents à gogo), lancer le chantier **formes de livraison §2** (durcir `tom-sdk`, binding WASM, TestFlight).
+6. Après chaque chantier : `/angle-mort` + `/code-review`, entrée journal, cocher §5.
+
+**Le cap est vert. On le garde. On itère jusqu'à ce que toutes les cases de §5 soient cochées — pas avant.**

--- a/docs/audits/AUDIT-2026-06-26.md
+++ b/docs/audits/AUDIT-2026-06-26.md
@@ -1,0 +1,777 @@
+# 🔬 ToM Protocol — Audit complet du codebase
+
+> **Date** : 2026-06-26  
+> **Commit** : e6d3501  
+> **Branche** : claude/tom-protocol-audit-yf42jz  
+> **Méthode** : 6 agents spécialisés (architecte, crypto, transport, protocol, groupes, tests) + synthèse consolidée. Règle zéro-hallucination : chaque affirmation tracée à fichier:ligne, sinon "NON TROUVÉ DANS LE CODE".
+
+---
+
+# 📊 ToM Protocol — État des Lieux Complet
+
+> Synthèse consolidée de 6 rapports d'audit (archi, crypto, transport, protocol, groups, tests). Chaque affirmation est tracée à `fichier:ligne` dans les rapports sources.
+
+---
+
+## Executive Summary
+
+| Métrique | Valeur | Source |
+|---|---|---|
+| LOC Rust totales (.rs, tests inclus) | **≈ 156 600** | [archi] total |
+| Crate le plus gros (hub) | tom-protocol **28 658 LOC**, 40 fichiers | [archi] |
+| Transport (fork iroh) | tom-connect **22 900 LOC**, 43 fichiers | [archi] |
+| QUIC proto (fork) | tom-quinn-proto **41 682 LOC**, 60 fichiers | [archi] |
+| Crates Rust | **18** (dont 2 hors workspace : tom-quinn-udp, tom-protocol-ffi) | [archi] |
+| Tests Rust `#[test]`/`#[tokio::test]` (somme) | **≈ 1 278** | [tests] §1 |
+| Tests réellement exécutés en CI | **≈ 1 009** (≈139 jamais lancés) | [tests] §5 |
+| Tests TypeScript (legacy) | 35 fichiers `*.test.ts` (771 annoncés, non vérifié) | [tests] §1 |
+| LOC Swift | **NON TROUVÉ DANS LES RAPPORTS** (FFI C audité, code Swift hors périmètre) | — |
+| Jobs CI | 10 (`ci.yml`) + 3 release workflows | [tests] §3 |
+
+---
+
+## Maturité par composant
+
+| Composant | État | Confiance | Bloqueurs principaux |
+|---|---|---|---|
+| **Crypto E2E** | 🟢 Vert | Élevée | Double-version dalek (2.2.0 + 3.0.0-pre.1) viole le pin ; pas de PCS/ratchet (assumé v1) |
+| **Transport / NAT** | 🟢 Vert | Élevée | Wire invariants divergent de la doc ; terrain validé 100% holepunch |
+| **Protocol / Routing** | 🟡 Jaune | Élevée | ACK entrant non vérifié (verrou #1) ; purge SQLite hub jamais déclenchée (verrou #2) |
+| **Groups / Failover** | 🔴 Rouge | Élevée | Failover hub **mort au runtime** ; split-brain/hub hijack non gardé |
+| **SDK / FFI** | 🟡 Jaune | Moyenne | tom-sdk : 0 test détecté ; tom-protocol-ffi hors workspace |
+| **Tests / CI** | 🟡 Jaune | Élevée | pre-push-gate ignore Rust ; tom-connect/dht/integration jamais testés en CI |
+| **Discovery DHT** | 🟡 Jaune | Élevée | Squatting de slot toujours possible (8 slots, PoP hors tom-dht) ; absent de CI |
+
+---
+
+## ✅ CE QUI EST ACQUIS
+
+### Architecture
+- DAG de dépendances **acyclique et stratifié** (QUIC → relay/gossip → connect → transport → protocol → app/SDK/FFI), aucun cycle détecté ([archi] graphe).
+- Séparation transport/protocol/SDK respectée au niveau déclaratif ([archi] cohérence globale).
+
+### Crypto (🟢 conforme spec v1)
+- Stack complète Ed25519 + X25519 DH éphémère + HKDF-SHA256 + XChaCha20-Poly1305 ([crypto] §1, `crypto.rs:8-21`).
+- **Encrypt-then-sign** conforme ADR-004 (`envelope.rs:259-268`), vérifié par vecteur `encrypt_then_sign_order`.
+- `verify_strict` (rejette malléabilité) `envelope.rs:150`, `key.rs:129`.
+- `signing_bytes` exclut `ttl` ET `signature`, testé (`envelope.rs:90-103`, vecteur `ttl_mutation_in_transit`).
+- **Anti-replay nonce E2E AVEC purge TTL 24h** + LRU 50k (`router.rs:33-37,197-206`) → résout KL#7.
+- **ACK signé à l'émission** (`state.rs:818,829,854`).
+- **Rendezvous DHT avec proof-of-possession signée** (`loop.rs:743-746`) → résout partiellement KL#2.
+- `SecretKey` `ZeroizeOnDrop` (`key.rs:235`) ; conversion Ed→X conforme libsodium, clamping testé.
+- 7 vecteurs de test crypto, 23 tests `crypto::` PASS ([crypto] §5).
+
+### Transport / Network (🟢 terrain validé)
+- Hole punching via **extension QUIC NAT-traversal `iroh_hp`** (PAS DISCO/CallMeMaybe) — `remote_state.rs:710`, `iroh_hp.rs`.
+- QAD (QUIC Address Discovery) pour adresse publique (`net_report.rs:329`).
+- **Relay stateless confirmé** : drop immédiat si destinataire absent, aucune persistance (`clients.rs:185-188`) → conforme verrou 3.
+- ALPN tous tom-namespacés (`tom-protocol/transport/0`, `/tom-gossip/1`).
+- Rendezvous DHT : namespace constant, 8 slots, fraîcheur <2h (`tom-dht/src/lib.rs:38-61`).
+- **Zombie detection mitigée** (KL#1) : liveness stale 45s + reconnect 15s (`loop.rs:34,502-506`).
+- Gate publication relay robuste (CGNAT 100.64/10, ULA, link-local, DNS local-only) `state.rs:2564`.
+- Résultats terrain : holepunch **100%** LAN/4G/cross-border, stress 4G **99.85%**, Campaign V5 **250/250** ([transport] §8, README).
+
+### Protocol
+- `Envelope` 10 champs conforme spec §2 (`envelope.rs:14-35`) ; 36 `MessageType` conformes (`types.rs:7-50`).
+- Dedup at-least-once + idempotence via `ReAck` sur duplicata (`router.rs:74-77`).
+- Backup virus : TTL 24h clampé, self-delete sur ACK, purge in-memory conforme (`coordinator.rs:166-271`) → verrou #2 OK pour le backup.
+
+### Groups / Roles
+- **Backup virus conforme verrou 2** : TTL 24h, purge `cleanup_expired`, self-delete sur ConfirmDelivery (`store.rs:199-224`).
+- **Verrou 4** : kick admin-only, **aucune blocklist/ban**, rejoin immédiat possible (`hub.rs:921-966`).
+- **Verrou 3** : RoleManager agit sur topology locale, n'arbitre rien centralisé (`manager.rs:161-208`).
+- **Verrou 5** : antispam token-bucket, `min_rate=30` jamais 0 (`antispam.rs:163`).
+- Scoring : fade exponentiel 0.05/h, score jamais 0 (`scoring.rs:8,171`).
+
+### Tests / CI
+- 10 jobs CI, proptest sur envelope/signature/crypto + quinn-proto, supply-chain `cargo-deny` ([tests] §3).
+- tom-protocol : **609 tests** (529 unit + 80 intégration, 13 fichiers).
+
+---
+
+## 🔄 CE QUI EST EN COURS
+
+| Feature | Progress | Fichier | Bloqueur |
+|---|---|---|---|
+| Rendezvous DHT anti-squat | ~60% (PoP signée OK) | `loop.rs:752-767` | PoP **hors tom-dht** (`lib.rs:302-339` ne vérifie jamais `addr.sig`) ; squat de slot toujours possible ; 8 slots non augmentés |
+| Failover hub Primary/Shadow/Candidate | structures+tests OK, **runtime mort** | `manager.rs:846,880-887` | `record_ping_failure` jamais appelé hors tests ; `should_promote` exige `ping_failures>=1` → impossible |
+| Verrou #1 ACK auth | partiel (ACK signé sortant) | `state.rs:872-891` | ACK **entrant** non gaté sur `signature_valid` |
+| Verrou #2 purge SQLite | bug actif | `state.rs:536-537` | cutoff absolu `TTL_MS` au lieu de `now - TTL_MS` → table jamais purgée |
+| Couverture CI Rust | partielle | `ci.yml` | tom-connect/dht/gateway/tui/integration absents de CI |
+| Pin dalek unifié | non fait | `tom-protocol/Cargo.toml:20,23` | déclare `"2"` au lieu de `=3.0.0-pre.1` |
+
+---
+
+## 🎯 LA CIBLE (phases à venir)
+
+Déduite des gaps confirmés (non inventée) :
+
+1. **Phase failover réel** : câbler la détection de HubPong manquant au runtime, corriger `should_promote`, implémenter le tier Candidate, émettre `HubUnreachable` côté membre.
+2. **Phase verrous critiques** : gater l'ACK entrant sur signature (verrou #1) ; corriger le cutoff de purge SQLite (verrou #2).
+3. **Phase anti-squat DHT** : porter la vérification PoP dans tom-dht, augmenter le nombre de slots, anti-DoS de slot.
+4. **Phase PCS (optionnelle, post-v1)** : Double Ratchet pour post-compromise security (absent, assumé par spec v1).
+5. **Phase couverture CI** : faire passer pre-push-gate par cargo, exécuter tom-connect/dht/integration en CI.
+
+---
+
+## ⚠️ GAPS / RISQUES
+
+| Gap | Impact | Effort | Reco |
+|---|---|---|---|
+| **Failover hub mort au runtime** | 🔴 Si le hub tombe, aucun basculement — groupes gelés | Élevé | Câbler timeout HubPong → `record_ping_failure` ; corriger `should_promote` ([groups] #1-2) |
+| **Split-brain / hub hijack** | 🔴 Tout nœud peut rediriger un groupe (`handle_hub_migration` accepte tout `new_hub_id`) | Moyen | Authentifier l'émetteur du `HubMigration` (`manager.rs:449-465`) |
+| **ACK entrant non vérifié (verrou #1)** | 🔴 ACK forgé promeut un message à `Delivered` | Faible | Gater l'arm `RoutingAction::Ack` sur `signature_valid` (`state.rs:872`) |
+| **Purge SQLite hub jamais déclenchée (verrou #2)** | 🔴 `hub_message_history` croît indéfiniment, dépasse TTL 24h | Trivial | `store.cleanup_hub_messages(now - TTL_MS)` (`state.rs:536`) |
+| **Double-version dalek (2.2.0 + 3.0.0-pre.1)** | 🟠 Surface d'attaque/maintenance doublée, viole pin doc #8 | Moyen | Aligner tom-protocol sur `=3.0.0-pre.1` via tom-base ([crypto] §4) |
+| **Squat de slot DHT** | 🟠 Attaquant occupe 8 slots, masque vrais pairs (PoP n'empêche pas le DoS) | Moyen | Augmenter slots + PoP dans tom-dht ([transport] §9) |
+| **Livraison non bloquée sur sig invalide (chat)** | 🟠 Message falsifié atteint l'app | Faible | Rejeter Chat non signé ou documenter contrat consommateur ([crypto] §3) |
+| **pre-push-gate ignore Rust** | 🟠 Gate locale verte sans compiler/tester Rust | Faible | Détecter stack Rust dans `pre-push-gate.sh:70-84` |
+| **tom-connect (78) / tom-dht (20) jamais testés en CI** | 🟠 ~139 tests morts en CI, cœur discovery non couvert | Faible | Ajouter `cargo test -p tom-connect/-p tom-dht` |
+| **tom-quinn-udp orphelin (2 397 LOC)** | 🟡 Dette morte, hors workspace, zéro consommateur | Faible | Supprimer ou marquer expérimental ([archi] risque 1) |
+| **Layer skipping (tom-connect direct)** | 🟡 Abstraction tom-transport contournable | Moyen | Étanchéifier la façade ([archi] risque 2) |
+| **Const failover inutilisées** | 🟡 `HUB_HEARTBEAT_INTERVAL_MS`, `SHADOW_PING_TIMEOUT_MS`, etc. | — | Implémenter la détection ou retirer ([groups] #6) |
+| **Wire invariants doc ≠ code** | 🟡 `.tom.invalid`, `X-Tom-*` au lieu d'iroh ; **PAS wire-compatible iroh** | Faible | Corriger CLAUDE.md (contredit "stay compatible with iroh") ([transport] §3) |
+| **Pas de `cargo fmt --check` ni coverage en CI** | 🟡 Format/couverture non garantis | Faible | Ajouter step fmt + outil coverage ([tests] §5) |
+| **tom-sdk 0 test détecté** | 🟡 SDK consommateur non couvert | Faible | Confirmer/peupler `two_clients.rs` ([tests] §1) |
+
+### Known Limitations — état réel vs CLAUDE.md
+
+| KL# | Sujet | Statut réel confirmé |
+|---|---|---|
+| #1 | Connexions zombies | **Mitigé** (liveness 45s) [transport] §6 |
+| #2 | Rendezvous squattable | **Partiel** : PoP signée OK, mais squat de slot + PoP hors tom-dht subsistent [transport] §9 |
+| #5 | Livraison ACK | **Aggravé/précisé** : ACK signé sortant MAIS entrant non vérifié + purge SQLite buggée [protocol] §4,6 |
+| #6 | Adresses DHT non filtrées | **Adressé** (filtre `direct_addr_is_dialable`) [transport] §7 |
+| #7 | Nonce sans purge TTL | **Résolu** (purge 24h présente) [protocol] §8 |
+| #9 | Détection relais offline | **Atténué**, pas de ping dédié [transport] §9 |
+
+---
+
+## 📋 Conformité 7 Verrous
+
+| # | Verrou | Statut | Preuve fichier:ligne |
+|---|---|---|---|
+| **1** | ACK destinataire ⟺ livré | ❌ | ACK entrant non gaté sur `signature_valid` → ACK forgé promeut à `Delivered` (`state.rs:872-891`, [protocol] §4) |
+| **2** | TTL 24h purge globale | ⚠️ | Backup virus conforme (`store.rs:199-224`) MAIS `hub_message_history` SQLite **jamais purgé** (cutoff bug `state.rs:536`, [protocol] §6) |
+| **3** | L1 ancre, jamais arbitre | ✅ | Relay pur pass-through (`clients.rs:177-212`) ; RoleManager local (`manager.rs:161-208`) — [transport] §10, [groups] |
+| **4** | Réputation fade, pas de ban | ✅ | Scoring jamais 0 (`scoring.rs:171`) ; kick sans blocklist, rejoin immédiat (`hub.rs:921-966`) — [groups] |
+| **5** | Anti-spam progressif | ✅ | Antispam `min_rate=30` jamais 0 (`antispam.rs:163`) ; rate-limit hub 5/s = limite fan-out distincte — [groups] |
+| **6** | Protocole invisible end-user | ✅ | Transport sans état exposé ; events de path = observabilité interne (`protocol.rs:148`) ; KL#8 vérifiée non-exposée — [transport] §10 |
+| **7** | Fondation universelle | ✅ | Pas de logique produit ; transport pur. Aucune violation relevée par les rapports |
+
+**Verdict verrous : 5 ✅, 1 ⚠️ (#2), 1 ❌ (#1).** Les deux écarts (#1, #2) sont des **bugs localisés et corrigeables** (`state.rs:536`, `state.rs:872`), pas des défauts de conception.
+
+---
+
+## 🚀 Recommandations priorisées
+
+### Immédiat (bugs verrous, effort faible/trivial)
+1. **Corriger la purge SQLite** : `state.rs:536` → `store.cleanup_hub_messages(now.saturating_sub(TTL_MS))` (verrou #2, trivial).
+2. **Gater l'ACK entrant** sur `signature_valid` à l'arm `RoutingAction::Ack` `state.rs:872` (verrou #1, faible).
+3. **Faire passer pre-push-gate par cargo** (`pre-push-gate.sh:70-84`) — sinon tout le Rust échappe au gate.
+
+### Court terme
+4. **Câbler le failover hub** : détection HubPong manquant → `record_ping_failure`, corriger `should_promote` (`manager.rs:846,880`). Sans ça, le watchdog documenté est fictif.
+5. **Authentifier `HubMigration`** contre split-brain/hijack (`manager.rs:449-465`).
+6. **Unifier le pin dalek** sur `=3.0.0-pre.1` dans tom-protocol (`Cargo.toml:20,23`).
+7. **Ajouter tom-connect / tom-dht / tom-integration-tests en CI**.
+
+### Moyen terme
+8. **Anti-squat DHT** : porter PoP dans tom-dht (`lib.rs:302-339`), augmenter le nombre de slots.
+9. **Étanchéifier tom-transport** (supprimer les deps tom-connect directes des sommets applicatifs).
+10. **Supprimer/clarifier tom-quinn-udp** (crate orphelin) ; corriger les wire invariants dans CLAUDE.md.
+11. **Tier Candidate + émission HubUnreachable côté membre** ; ajouter `cargo fmt --check` + coverage en CI.
+12. **PCS / Double Ratchet** (post-v1, si menace compromission long-terme retenue).
+
+---
+
+## Annexe — Warnings / écarts rencontrés par les agents
+
+- **CLAUDE.md inexact (wire invariants)** : la doc prétend `.iroh.invalid`, `X-Iroh-*`, ALPN `/iroh-qad/0` ; le code dit `.tom.invalid` (`tls/name.rs:19`), `X-Tom-*` (`relay/main.rs:35`), ALPN tom-* uniquement. **Conséquence : tom-relay PAS wire-compatible avec le réseau iroh** — contredit l'affirmation CLAUDE.md. ([transport] §3)
+- **Subsistent en dur (vrais invariants iroh)** : hostnames `*.iroh-canary.iroh.link`, `dns.iroh.link/pkarr` ([transport] §3).
+- **`ReAck`** : variante `RoutingAction` non documentée (spec ni tâche), mais justifiée (ré-émission ACK sur duplicata) ([protocol] §3).
+- **CLAUDE.md "watchdog 3s ping ~6s promote"** : structures+tests présents mais **non raccordés au runtime** — divergence majeure code/doc ([groups] conclusion).
+- **`elect_hub` (lowest NodeId)** : documenté mais **code mort runtime**, aucun appelant hors tests ([groups]).
+- **tom-sdk `two_clients.rs`** : 0 `#[test]` détecté au grep — **NON CONFIRMÉ** au-delà du count ([tests] §1).
+- **771 tests TypeScript** annoncés : seuls 35 fichiers `*.test.ts` vérifiés, count d'assertions **non vérifié** ([tests] §1).
+- **LOC Swift** : **NON TROUVÉ DANS LES RAPPORTS** (seul le FFI C a été audité ; code Swift hors périmètre des 6 agents).
+- **cargo-deny `licenses` désactivé** ; 4 advisories ignorées (RUSTSEC rand/lru/paste/atomic-polyfill) ([tests] §4).
+
+
+---
+
+# 📎 Annexes — Rapports détaillés par agent
+
+
+## Annexe A — Architecte Système
+
+## Architecture Report — ToM Protocol
+
+### Crates Map
+
+| Crate | Rôle (description Cargo.toml + lib.rs) | Deps internes tom-* | LOC | Fichiers .rs |
+|---|---|---|---|---|
+| **tom-base** | Types crypto de base (PublicKey/SecretKey/NodeAddr), fork iroh-base 0.96 (`tom-base/Cargo.toml:5`) | — (feuille) | 827 | 4 |
+| **tom-quinn-proto** | Protocole QUIC, fork iroh-quinn-proto | — (feuille) | 41 682 | 60 |
+| **tom-quinn** | Runtime QUIC, fork iroh-quinn | tom-quinn-proto (`:162`) | 6 512 | 13 |
+| **tom-quinn-udp** | Sockets UDP+ECN (`:23`). **EXCLU du workspace** (`Cargo.toml:7`), aucun consommateur path → forks utilisent `iroh-quinn-udp` upstream à la place | — | 2 397 | 7 |
+| **tom-metrics** | Counter simplifié | — (feuille) | 212 | 1 |
+| **tom-relay** | Serveur relais stateless, fork iroh-relay | tom-base, tom-quinn, tom-quinn-proto (`:16,23,24`) | 11 787 | 28 |
+| **tom-gossip** | Protocole gossip, fork iroh-gossip | tom-connect(opt), tom-base, tom-metrics (`:25,28,29`) | 6 572 | 13 |
+| **tom-connect** | Transport: MagicSock, Disco, hole punching, fork iroh | tom-quinn, tom-quinn-proto, tom-base, tom-relay, tom-metrics (`:11,12,28,29,30`) | 22 900 | 43 |
+| **tom-dht** | Discovery DHT BEP-0044 mutable (`:6`) | — (feuille, autonome) | 802 | 1 |
+| **tom-transport** | Couche transport QUIC stable au-dessus de tom-connect (`:6`) | tom-connect, tom-base, tom-gossip (`:10,11,12`) | 2 365 | 9 |
+| **tom-protocol** | Routing, crypto E2E, groupes, backup, rôles, runtime | tom-transport, tom-dht, tom-metrics, tom-connect, tom-gossip, tom-relay (`:9,10,34,40,41,46`) | 28 658 | 40 |
+| **tom-sdk** | Façade stable haut niveau au-dessus de tom-protocol (`:6`) | tom-protocol, tom-transport (`:13,14`) | 967 | 5 |
+| **tom-tui** | Client chat TUI (ratatui) | tom-transport, tom-protocol, tom-base (`:12,13,24`) | 1 274 | 1 |
+| **tom-stress** | Campagnes de stress test | tom-transport, tom-protocol, tom-connect (`:18,19,30`) | 5 523 | 23 |
+| **tom-gateway** | CLI auto-config NAT Freebox pour le relais (`:6`) | — (autonome, aucune dep tom-*) | 1 052 | 4 |
+| **tom-integration-tests** | Tests d'intégration cross-crate | tom-protocol, tom-transport, tom-relay (`:9,10,11`) | 1 005 | 1 |
+| **tom-protocol-ffi** | API C pour Swift/tvOS. **EXCLU du workspace** (`Cargo.toml:7`) | tom-protocol, tom-transport, tom-connect (`:12,13,14`) | 1 559 | 2 |
+| **tom-relay-ffi** | Wrapper FFI C du relais pour Swift/tvOS (`:5`) | tom-relay (`:13`) | 246 | 1 |
+
+**Total ≈ 156 600 LOC** (toutes lignes .rs, tests inclus).
+
+### Graphe de dépendances (texte)
+
+```
+Feuilles:  tom-base   tom-quinn-proto   tom-metrics   tom-dht   tom-quinn-udp(orphelin)   tom-gateway(autonome)
+
+tom-quinn ──> tom-quinn-proto
+tom-relay ──> tom-base, tom-quinn, tom-quinn-proto
+tom-gossip ──> tom-base, tom-metrics, [tom-connect (opt)]
+tom-connect ──> tom-quinn, tom-quinn-proto, tom-base, tom-relay, tom-metrics
+tom-transport ──> tom-connect, tom-base, tom-gossip
+tom-protocol ──> tom-transport, tom-dht, tom-metrics, tom-connect, tom-gossip, tom-relay
+
+Sommets applicatifs:
+  tom-sdk ──> tom-protocol, tom-transport
+  tom-tui ──> tom-transport, tom-protocol, tom-base
+  tom-stress ──> tom-transport, tom-protocol, tom-connect
+  tom-protocol-ffi ──> tom-protocol, tom-transport, tom-connect   (hors workspace)
+  tom-relay-ffi ──> tom-relay                                      (hors workspace)
+  tom-integration-tests ──> tom-protocol, tom-transport, tom-relay
+```
+
+**Cycles**: AUCUN cycle détecté. Le DAG est acyclique et stratifié (QUIC → relay/gossip → connect → transport → protocol → app/SDK/FFI).
+
+### Points d'entrée
+
+- **tom-sdk/src/lib.rs:1** — façade `TomClientBuilder`/`Event`, "aucun type des crates internes", API publique stable.
+- **tom-protocol/src/lib.rs:8-21** — 13 modules publics: `backup, crypto, discovery, envelope, error, group, relay, roles, router, runtime, storage, tracker, types`.
+- **tom-transport/src/lib.rs:30-38** — 9 modules: `bootstrap, config, connection, envelope, error, node, path, protocol`. Expose `TomNode::bind`.
+- **tom-connect** — fork iroh (MagicSock/Disco), 43 fichiers, le plus gros crate transport.
+- **tom-relay/src/lib.rs:31-47** — modules `client, defaults, http, protos, quic, server, dns, endpoint_info`. `Server` consommé par tom-relay-ffi.
+- **tom-gateway/src/main.rs:1** — binaire CLI (`Auth`/`Setup` NAT Freebox), indépendant du stack protocole.
+
+### Crates non documentés dans CLAUDE.md — rôle réel
+
+- **tom-gateway** — CLI d'auto-config NAT Freebox pour exposer le relais (port 3340 UDP+TCP). Modules `freebox, nat, token`. **Aucune dépendance tom-***: outil ops isolé (`tom-gateway/Cargo.toml:6`, `main.rs`).
+- **tom-sdk** — façade stable haut niveau au-dessus de tom-protocol, API minimale sans types internes (`tom-sdk/src/lib.rs:8-11`).
+- **tom-transport** — couche transport QUIC (hole punching, relay fallback) enveloppant tom-connect derrière une API stable; intercalée entre tom-connect et tom-protocol (`tom-transport/src/lib.rs:1-4`).
+- **tom-relay-ffi** — wrapper FFI C exposant `tom_relay_start/stop/status` à Swift/tvOS, runtime tokio interne (`tom-relay-ffi/src/lib.rs:1-30`).
+- **tom-quinn-udp** — fork de sockets UDP+ECN, mais **EXCLU du workspace** (`Cargo.toml:7`) et **sans aucun consommateur** : tom-connect et tom-quinn utilisent `iroh-quinn-udp` upstream à la place (`tom-connect/Cargo.toml:13`, `tom-quinn/Cargo.toml:203`). Cohérent avec CLAUDE.md "Not forked (intentional): iroh-quinn-udp".
+
+### Risques structurels
+
+1. **tom-quinn-udp = crate mort/orphelin** (`Cargo.toml:7`). Présent dans `crates/`, exclu du workspace, zéro consommateur, alors que le code réel utilise `iroh-quinn-udp` upstream. 2 397 LOC non buildées/non testées par `cargo --workspace`. Contradiction avec la doc qui affirme "Not forked". Risque: dette morte, divergence silencieuse, confusion. **Recommandation: supprimer ou documenter explicitement comme expérimental.**
+
+2. **Bypass de couches (layer skipping) par les sommets applicatifs.** `tom-protocol/Cargo.toml:40` dépend de tom-connect ET tom-transport (transport enveloppe pourtant déjà connect). Idem `tom-stress/Cargo.toml:30` et `tom-protocol-ffi/Cargo.toml:14` court-circuitent tom-transport en tapant tom-connect direct. La façade tom-transport n'est donc pas étanche → fuite d'abstraction, l'API "stable" est contournable.
+
+3. **Deux FFI hors workspace** (`tom-protocol-ffi`, `tom-quinn-udp` exclus, `Cargo.toml:7`). `cargo test/clippy --workspace` ne couvre PAS tom-protocol-ffi (1 559 LOC) → risque de breakage cross-crate masqué, confirmé par CLAUDE.md (note #10). tom-relay-ffi, lui, EST dans le workspace (members) → asymétrie de traitement entre les deux FFI.
+
+4. **tom-protocol = hub massif (28 658 LOC, 6 deps internes, 13 modules publics).** Point de couplage central; toute modif de tom-connect/relay/gossip/dht/transport remonte ici. Cohérent avec la règle "Cross-Crate Validation" mais concentre le risque de régression.
+
+5. **tom-gossip dépend optionnellement de tom-connect** (`:25`, `optional = true`) alors que tom-connect dépend de tom-relay et tom-gossip dépend de tom-connect: pas de cycle (la branche connect de gossip est optionnelle et connect ne dépend pas de gossip), mais couplage croisé à surveiller si la feature opt devient default.
+
+6. **tom-tui = 1 274 LOC dans 1 seul fichier** (`tom-tui/src`, 1 fichier .rs) et **tom-dht = 802 LOC en 1 fichier**. Fichiers monolithiques, faible modularité interne (vs séparation responsabilités attendue §8/§9).
+
+**Cohérence globale**: stratification propre, DAG acyclique, séparation transport/protocol/SDK respectée au niveau déclaratif. Faiblesses concentrées sur (a) le crate orphelin tom-quinn-udp, (b) les fuites d'abstraction via tom-connect direct, (c) l'asymétrie de couverture CI des FFI.
+
+
+---
+
+## Annexe B — Crypto & Sécurité
+
+J'ai assez d'éléments. Le seed vient de `secret_key().to_bytes()` (tom-base v3, retourne le seed 32o), puis passé à `ed25519_dalek::SigningKey::from_bytes` (v2 dans tom-protocol). Comme le seed est juste `[u8;32]`, il n'y a pas de type-mismatch — c'est un format stable. Mais c'est une duplication de version potentiellement problématique. Je rédige le rapport.
+
+## Crypto & Security Report — ToM Protocol
+
+### 1. Tableau des primitives
+
+| Usage | Algo | Lib (Cargo.toml déclaré / Cargo.lock résolu) | fichier:ligne |
+|---|---|---|---|
+| Identité / signature | Ed25519 (`verify_strict`) | `ed25519-dalek` "2" → **2.2.0** (tom-protocol) ; `=3.0.0-pre.1` (tom-base) | `crates/tom-protocol/src/envelope.rs:130,143,148,150` ; `crates/tom-base/src/key.rs:13,127,291` |
+| Accord de clé | X25519 DH éphémère (1 keypair/message) | `x25519-dalek` "2" → **2.0.1** (`static_secrets`) | `crates/tom-protocol/src/crypto.rs:16,104-108,146` |
+| Conversion Ed→X (pk) | Edwards→Montgomery birational | `curve25519-dalek` "4" → **4.1.3** (tom-protocol) ; `=5.0.0-pre.1` (tom-base) | `crates/tom-protocol/src/crypto.rs:12,53-60` |
+| Conversion Ed→X (sk) | SHA-512(seed)[0..32] + clamping | `sha2` 0.10 | `crates/tom-protocol/src/crypto.rs:66-75` |
+| Dérivation clé | HKDF-SHA256 (salt=None, info domain tag) | `hkdf` 0.12 / `sha2` 0.10 | `crates/tom-protocol/src/crypto.rs:13,21,78-84` |
+| Chiffrement AEAD | XChaCha20-Poly1305 (nonce 24o, tag 16o) | `chacha20poly1305` 0.10 → **0.10.1** | `crates/tom-protocol/src/crypto.rs:8-11,110,118,171,187` |
+| RNG | `OsRng` (CSPRNG) | `chacha20poly1305::aead::rand_core::OsRng` | `crates/tom-protocol/src/crypto.rs:97,104,113-114,161-163,170-173` |
+| Zéroïsation seed | `ZeroizeOnDrop` sur `SecretKey` | `zeroize` 1.8 | `crates/tom-base/src/key.rs:235-236` |
+
+### 2. Flow crypto (message direct E2E)
+
+Émission `encrypt_and_sign` (`envelope.rs:259-268`) — **encrypt-puis-sign** (ADR-004) :
+1. pk Ed25519 destinataire → X25519 (`crypto.rs:53-60`)
+2. keypair X25519 éphémère OsRng (`crypto.rs:104-105`)
+3. `shared = DH(ephemeral_sk, recipient_x_pk)` (`crypto.rs:108`)
+4. `key = HKDF-SHA256(None, shared, info="tom-protocol-e2e-xchacha20poly1305-v1", 32)` (`crypto.rs:21,78-84`)
+5. nonce 24o aléatoire ; `XChaCha20-Poly1305(key,nonce,pt)` (`crypto.rs:113-120`)
+6. `EncryptedPayload{ciphertext,nonce[24],ephemeral_pk[32]}` → MsgPack dans `payload`, `encrypted=true` (`envelope.rs:159-167`)
+7. `sign` Ed25519 sur `signing_bytes()` (exclut `signature` ET `ttl`) (`envelope.rs:90-103,129-133`)
+
+Réception (`state.rs:1392-1414`, `state.rs:784-822`) : `verify_signature()` strict → `decrypt_payload` (`crypto.rs:134-157`) → livraison.
+
+Groupe : Sender Key symétrique 32o (`crypto.rs:160-192`), GroupMessage **signé** par expéditeur, vérifié au hub (`group/hub.rs:476-477`, `group/types.rs:480-495`).
+
+### 3. Checklist sécurité
+
+- [x] AEAD authentifié, échecs rejetés sans distinction (`crypto.rs:154` mappe tout en erreur générique — pas d'oracle de padding)
+- [x] `verify_strict` (rejette signatures non-canoniques / malléabilité) `envelope.rs:150`, `key.rs:129`
+- [x] Nonce XChaCha 24o aléatoire OsRng (collision négligeable, conçu pour random)
+- [x] `signing_bytes` déterministe MsgPack, exclut `ttl` (relais peuvent muter sans casser sig) `envelope.rs:90-103`
+- [x] Anti-replay nonce E2E **avec purge TTL 24h** + LRU borné 50k (résout gap #7) `router.rs:33-37,235-247,197-206`
+- [x] Anti-replay ACK (5min) + dedup message (10min) `router.rs:20-24,301-304`
+- [x] ACK **signé** (verrou #1) `state.rs:818,829,854`
+- [x] Rendezvous DHT avec proof-of-possession signée (résout gap #2) `runtime/loop.rs:743-746,763-766`
+- [x] `SecretKey` `ZeroizeOnDrop` `key.rs:235`
+- [x] Conversion Ed→X25519 conforme libsodium, clamping vérifié par test `crypto.rs:316-322`
+- [x] HKDF pinned vector (anti-régression silencieuse) `crypto.rs:424-439`
+- [x] Décompression pk invalide rejetée `crypto.rs:55-57`
+- [ ] **Forward secrecy : par-message uniquement** (éphémère X25519 jeté). Spec le confirme : "Pas de ratchet, pas de post-compromise security en v1" `tom-crypto-v1.md:54-56`
+- [ ] **Double Ratchet : ABSENT** — `grep ratchet` → NON TROUVÉ DANS LE CODE (seule occurrence = commentaire d'absence). PCS non assurée.
+- [ ] **Message livré même si signature invalide/absente** — `signature_valid` est calculé et propagé à l'app (`state.rs:1393-1397,813`) mais ne bloque PAS la livraison (`handle_incoming_chat` livre inconditionnellement `state.rs:808-815`)
+- [ ] **AEAD non lié à l'identité** : aucun AAD ; un tiers peut chiffrer vers une pk (authenticité vient SEULEMENT de la sig d'enveloppe) `tom-crypto-v1.md:55` ; pas de binding `from` dans l'AEAD
+- [ ] **Métadonnées en clair** (`from`,`to`,`via`,`msg_type`,`timestamp`) `tom-crypto-v1.md:57`
+
+### 4. Tableau vulnérabilités
+
+| Risque | Sévérité | fichier:ligne | Reco |
+|---|---|---|---|
+| **Double version ed25519-dalek (2.2.0 + 3.0.0-pre.1) & curve25519-dalek (4.1.3 + 5.0.0-pre.1)** dans le même binaire. tom-protocol viole le pin `=3.0.0-pre.1` exigé (CLAUDE.md note #8) en déclarant `"2"`. Le seed transite en `[u8;32]` brut (`node.rs:428`→`envelope.rs:130`) donc pas de mismatch de type bloquant, mais surface d'attaque/maintenance doublée et divergence pin documenté vs réel | Moyenne | `crates/tom-protocol/Cargo.toml:20,23` ; `Cargo.lock` (2.2.0 et 3.0.0-pre.1) | Aligner tom-protocol sur `ed25519-dalek = "=3.0.0-pre.1"` et `curve25519-dalek = "=5.0.0-pre.1"` via tom-base, supprimer le duplicata |
+| **Livraison sans rejet sur signature invalide** : `signature_valid=false` n'empêche pas `DeliverMessage`. Un message non signé ou falsifié (payload chiffré → sig échoue) atteint l'app | Moyenne | `crates/tom-protocol/src/runtime/state.rs:808-821,1393-1397` | Documenter explicitement que l'app DOIT vérifier `signature_valid`, ou rejeter les Chat non signés au niveau protocole |
+| **Pas de PCS / Double Ratchet** : compromission d'une clé d'identité permet de déchiffrer tous les futurs messages (FS par-message protège seulement le passé via éphémère) | Moyenne (assumé v1) | `crates/tom-protocol/src/crypto.rs` (absent) ; `docs/spec/tom-crypto-v1.md:54-56` | Roadmap ratchet pour PCS si menace de compromission long-terme retenue |
+| **AEAD sans AAD liant l'expéditeur** : n'importe qui chiffre vers une pk ; seul le wrapping signature lie `from`. Si un consommateur traite le plaintext déchiffré sans vérifier la sig → usurpation | Faible/Moyenne | `crates/tom-protocol/src/crypto.rs:118-120` | Inclure `from`/contexte en AAD, ou imposer la vérif sig avant exposition |
+| **Pas de test de régression chargeant `tom-vectors-v1.json`** : les vecteurs sont (re)générés et auto-vérifiés par `gen_test_vectors.rs` (assertions internes), mais aucun test ne charge le JSON figé pour détecter une dérive du fichier vs code | Faible | `crates/tom-protocol/examples/gen_test_vectors.rs` (pas de `include_str!` du JSON ailleurs) | Ajouter un `#[test]` qui charge `docs/spec/vectors/tom-vectors-v1.json` et l'oppose au code (decrypt/verify) |
+| **`encrypt_group_message` / `derive_key` utilisent `.expect()`** sur des opérations crypto. Acceptable (invariants garantis : clé 32o, taille HKDF fixe) mais panique-on-fail | Info | `crates/tom-protocol/src/crypto.rs:81-82,176-177` | OK en l'état (invariants tenus) ; documenter |
+
+### 5. Conformité spec (`docs/spec/tom-crypto-v1.md` + vecteurs)
+
+- Primitives spec §1 ⇔ code : **CONFORME** (`crypto.rs:8-21`).
+- Conversion Ed→X §2 ⇔ `crypto.rs:53-75`, clamping `b[0]&=248;b[31]&=127;b[31]|=64` exact : **CONFORME**, vecteur `ed25519_to_x25519` (`vectors:40-46`).
+- Flow encrypt-then-sign §3 ⇔ `envelope.rs:259-268` + vecteur `encrypt_then_sign_order` (`vectors:68-73`) : **CONFORME**.
+- `signing_bytes` exclut `ttl` §3 + ADR-003 ⇔ `envelope.rs:90-103`, vecteur `ttl_mutation_in_transit` (`vectors:32-38`) : **CONFORME**.
+- Sender Keys §4 ⇔ `crypto.rs:160-192`, vecteur `group_sender_key` (`vectors:60-67`) : **CONFORME**.
+- HKDF info exact `"tom-protocol-e2e-xchacha20poly1305-v1"` ⇔ `crypto.rs:21`, pinned vector `crypto.rs:424-439` : **CONFORME**.
+- Vecteurs présents : 7 (identity, signed_envelope, ttl_mutation, ed25519_to_x25519, e2e_decrypt, group_sender_key, encrypt_then_sign_order). **Passants** : générateur auto-vérifié (assertions `gen_test_vectors.rs:41,58,83,144,172,188`) + 23 tests `crypto::` PASS (exécutés). Limites §5 (FS par-message, pas de ratchet, métadonnées claires) **documentées et conformes au code**.
+
+**Verdict** : cryptographie solide et conforme à sa spec v1. Aucune faille de primitive. Risques principaux = **divergence de pin/double-version des libs dalek** (le plus actionnable) et **choix d'architecture** (livraison non bloquante sur sig invalide, absence de PCS) — assumés par la spec mais à expliciter côté consommateur.
+
+
+---
+
+## Annexe C — Transport & Réseau
+
+All wire identifiers are tom-namespaced. I have enough to write the report.
+
+## Transport & Network Report
+
+### 1. Stack transport (couches & ALPN)
+
+| Couche | Crate | Rôle | Preuve |
+|---|---|---|---|
+| API transport | `tom-transport` | `TomNode` (bind/send/recv), `ConnectionPool`, handler | `crates/tom-transport/src/node.rs:138-416` |
+| Endpoint/NAT | `tom-connect` | MagicSock, holepunch, QAD, relay fallback | `crates/tom-connect/src/socket.rs`, `endpoint.rs` |
+| QUIC runtime | `tom-quinn` | gestion connexions | (alias `quinn`) |
+| QUIC protocole | `tom-quinn-proto` | wire QUIC + extension NAT (`iroh_hp`) | `crates/tom-quinn-proto/src/iroh_hp.rs` |
+| Relay | `tom-relay` | serveur stateless WS + QUIC addr discovery | `crates/tom-relay/src/server/clients.rs` |
+| Discovery | `tom-dht`, `tom-gossip` | rendezvous DHT, gossip mesh | `crates/tom-dht/src/lib.rs`, `crates/tom-gossip/src/net.rs` |
+
+**ALPN réels (tous tom-namespacés)** :
+- Application transport : `b"tom-protocol/transport/0"` (`tom-transport/src/lib.rs:116`)
+- Gossip : `b"/tom-gossip/1"` (`tom-gossip/src/net.rs:46`)
+- Test ALPN interne : `b"n0/tom/test"` (`tom-connect/src/address_lookup.rs:621`)
+
+### 2. NAT traversal / hole punching — mécanisme exact
+
+Le hole punching n'utilise **PAS** le protocole DISCO classique d'iroh (CallMeMaybe). `grep CallMeMaybe/disco::Message` → **NON TROUVÉ**. Le mécanisme réel est l'**extension QUIC NAT-traversal** (`iroh_hp`) :
+
+- Orchestration : `crates/tom-connect/src/socket/remote_map/remote_state.rs:710` `trigger_holepunching()` → `do_holepunching()` (l.771).
+- Déclenche `conn.initiate_nat_traversal_round()` (l.780) → `crates/tom-quinn-proto/src/iroh_hp.rs`.
+- Holepunch sur la connexion client de plus petit `ConnId` (l.703-726), récupère candidats locaux + `get_remote_nat_traversal_addresses()` (l.727).
+- Intervalle : `HOLEPUNCH_ATTEMPTS_INTERVAL` (`remote_state.rs:49-51`) ; retry 100ms sur `NotEnoughAddresses`/`Multipath` (l.812).
+- Découverte d'adresse publique : **QAD** (QUIC Address Discovery) via `net_report.rs:329 spawn_qad_probes`, type `DirectAddrType::Qad` (`socket.rs:1609`).
+- Le relay sert aussi de keepalive Ping/Pong (`tom-connect/src/socket/transports/relay/actor.rs:559,683`) — ce sont des frames relay, pas du holepunch.
+
+### 3. QUIC — rôles & wire invariants (⚠️ CLAUDE.md INEXACT)
+
+`tom-quinn-proto` (protocole QUIC + extension `iroh_hp`), `tom-quinn` (runtime). **Les "wire invariants sacrés" listés dans CLAUDE.md ne correspondent PAS au code** — ils ont été renommés vers `tom` :
+
+| CLAUDE.md prétend | Réalité dans le code | fichier:ligne |
+|---|---|---|
+| SNI `.iroh.invalid` | **`.tom.invalid`** | `tom-connect/src/tls/name.rs:19,25` |
+| `X-Iroh-*` headers | **`X-Tom-NodeId`, `X-Tom-Challenge`, `X-Tom-Response`, `x-tom-relay-client-auth-v1`** | `tom-relay/src/main.rs:35`, `server.rs:59-60`, `http.rs:22` |
+| Protocole relay iroh | **`tom-relay-v1`** (sub-protocol WS) | `tom-relay/src/http.rs:20` |
+| ALPN `/iroh-qad/0` | QAD ALPN literal **NON TROUVÉ** dans tom-connect (seuls ALPN tom-* trouvés) | — |
+
+**Subsistent en dur (vrais invariants iroh, non renommés)** : hostnames relais N0 `*.iroh-canary.iroh.link` (`tom-connect/src/defaults.rs:26-32`), pkarr `dns.iroh.link/pkarr` (`address_lookup/pkarr.rs:126`), DNS origin `dns.iroh.link` (`tom-relay/src/dns.rs:32`). **Conséquence : tom-relay n'est PAS wire-compatible avec le réseau relay iroh** (protocole/headers divergents) — contredit l'affirmation CLAUDE.md "stay compatible with iroh network".
+
+### 4. Relay (statelessness, --dev, ports)
+
+- **Stateless confirmé** : `send_packet()` forwarde via canal mpsc vers le client connecté ; si destinataire absent → **drop immédiat**, aucune file ni persistance (`tom-relay/src/server/clients.rs:185-188`, `send_packets_dropped.inc()`). Conforme verrou 3.
+- **`--dev`** : HTTP plain, port **3340** (`tom-relay/src/main.rs:33,48-49`).
+- **Ports par défaut** (`tom-relay/src/defaults.rs`): HTTP 80, HTTPS 443, QUIC addr-discovery **7842**, metrics 9090.
+- `enable_relay=false` → relais holepunch-only (QAD seul, ne relaie aucune donnée) (`main.rs:90-93`).
+- `tom-relay-ffi` : non audité en détail (hors périmètre fichiers lus) — **NON VÉRIFIÉ**.
+
+### 5. Discovery
+
+- **Rendezvous DHT (ADR-010)** : namespace constant `b"tom-protocol-rendezvous-v1"` (`tom-dht/src/lib.rs:38`), **8 slots** (`RENDEZVOUS_SLOTS=8`, l.42), slot = `hash(node_id) % 8` (`slot_for_node`, l.57-61), salt `b"tom-rdv-v1"` (l.45), seq = timestamp (last-writer-wins, l.285). Fraîcheur < 2h (`MAX_DHT_AGE_MS`, filtre `rendezvous_entry_is_fresh`, l.318).
+- **Pkarr/DNS** : presets N0 activables via `n0_discovery` flag (`tom-transport/src/node.rs:244-262`).
+- **Fallback relais** : discovery HTTP `/relays` (node.rs:101-126) → DNS TXT (node.rs:69-99) → liste codée en dur `relay-{eu,us,asia}.tom-protocol.org` (`config::fallback_relay_urls`, vérifié test node.rs:1000-1007).
+- **Gossip** : `tom-gossip`, ALPN `/tom-gossip/1`.
+- **mDNS local** : `MdnsAddressLookup` si `local_discovery` (node.rs:374-398).
+
+### 6. Heartbeat / isolation / connexions zombies
+
+- **Known Limitation #1 (zombies) — MITIGÉ** : `reconnect_check` (intervalle **15s**, `loop.rs:76`) détecte l'isolement par `connected_peers().is_empty()` **OU** zombie = connecté mais `liveness_is_stale(last_inbound, 45s)` (`LIVENESS_STALE_MS=45_000`, l.34 ; logique l.502-506). Sur isolement → `bootstrap_phase.on_isolated()` (Converged→amorçage) + republish DHT + `spawn_rendezvous_round` immédiat (l.518-529). Tests l.923-942.
+- Send timeout : `open_bi` timeout 5s → éviction du pool (`node.rs:508-534`).
+- Détection des conns mortes au reuse : `conn.close_reason()` (`connection.rs:61`).
+
+### 7. Filtrage adresses globalement reachable
+
+- **Known Limitation #6 — ADRESSÉ** côté DHT direct addrs : `dht_addr_to_endpoint_addr` filtre via `direct_addr_is_dialable` (`loop.rs:688`), qui rejette loopback/unspecified/link-local/broadcast mais **garde les ranges privés LAN** (intentionnel pour same-LAN, l.700-702).
+- **Gate publication relay** (`state.rs:2564 relay_url_is_globally_reachable`) : robuste — gère IPv4/IPv6 littéraux, **CGNAT 100.64/10** (l.2606-2610), ULA fc00::/7, link-local, et DNS local-only (`.local/.internal/.lan/.home.arpa/localhost`, l.2585-2594).
+
+### 8. Résultats terrain (source : README.md)
+
+| Scénario | Résultat | Source |
+|---|---|---|
+| NAT hole punching | **100%** (LAN, 4G CGNAT, cross-border CH↔FR) | README.md:75 |
+| Stress 4G autoroute | **99.85%** (2748/2752 pings, 54 min) | README.md:76 |
+| Campaign V5 | **100% local, 250/250 Mac↔NAS** | README.md:77 |
+| Latence QUIC directe | **27-49ms** post-holepunch | README.md:80 |
+| LAN WiFi | holepunch 0.37s, RTT 49ms, 100% direct | README.md:190 |
+| 4G CGNAT | holepunch 2.9s, RTT 107ms, **90% direct** | README.md:191 |
+| Cross-border CH↔FR | holepunch 1.4s, RTT 32ms, **95% direct** | README.md:192 |
+
+### 9. Points de défaillance / risques
+
+1. **Squatting rendezvous (KL#2) — partiellement résolu.** La **proof-of-possession** est désormais vérifiée avant injection : `rendezvous_entry_authentic` (`loop.rs:752-767`) vérifie sig ed25519 sur `signing_bytes()`, drop si forgé (l.798). **MAIS** : (a) la vérification est dans tom-protocol, **PAS dans tom-dht** — `rendezvous_discover` (`tom-dht/src/lib.rs:302-339`) ne vérifie **jamais** `addr.sig` ; tout consommateur direct de tom-dht reste vulnérable. (b) Le **squatting de slot lui-même** reste possible : un attaquant publie une entrée auto-signée valide (son propre node_id) sur chaque slot (8 seulement, last-writer-wins) → occupe les slots et masque les vrais pairs. La PoP empêche le *poisoning* (faux addrs sur node_id d'autrui), pas le *squatting/DoS*.
+2. **8 slots = faible** : collisions writers et facilité d'occupation totale (KL#2 mentionnait "augmenter le nombre de slots" — non fait, toujours 8).
+3. **Wire invariants divergents non documentés** : risque de confusion d'intégration ; incompatibilité réelle avec relais iroh existants (cf. §3).
+4. **`send_raw` ne confirme rien au niveau transport** : `drop(recv)` volontaire (node.rs:551), s'appuie sur ACK protocole applicatif (cf. verrou 1).
+5. **Détection relais offline (KL#9)** : atténuée par liveness 45s + reprobe 15s, mais pas de ping relais dédié — **NON TROUVÉ** d'API ping relais dans tom-connect.
+6. `path_kind()` non implémenté (node.rs:578-581, retourne toujours `None`).
+
+### 10. Conformité verrous 2 / 3 / 6
+
+- **Verrou 2 (TTL 24h purge)** : **non géré au niveau transport** — le relay ne stocke rien (drop immédiat, clients.rs:186), donc pas de message à purger ici ; rendezvous DHT a sa propre fraîcheur 2h (`MAX_DHT_AGE_MS`). La purge TTL 24h est une responsabilité du backup (tom-protocol/backup), hors périmètre transport. **CONFORME par absence de persistance.**
+- **Verrou 3 (L1 ancre jamais arbitre)** : **CONFORME** — le relay est pur pass-through, ne décide rien sur le contenu, forwarde ou drop selon présence du destinataire (clients.rs:177-212). Aucune logique d'arbitrage observée.
+- **Verrou 6 (protocole invisible end-user)** : couche transport sans état exposé à l'utilisateur ; les events de path (`PathEvent`, protocol.rs:148) sont de l'observabilité interne. **CONFORME** au niveau transport (la frontière FFI/Swift est auditée ailleurs — KL#8 marquée vérifiée non-exposée).
+
+**Crates non lus en détail** (limite de l'audit) : `tom-relay-ffi`, internals `tom-quinn`/`tom-quinn-proto/iroh_hp.rs` (seule l'interface d'appel vérifiée), `tom-gateway`, `tom-sdk`.
+
+
+---
+
+## Annexe D — Protocol & Messages
+
+## Protocol & Messages Report
+
+### 1. Struct Message réelle (code, fichier:ligne)
+
+**`Envelope`** — `crates/tom-protocol/src/envelope.rs:14-35` :
+```rust
+pub struct Envelope {
+    pub id: String,            // UUID v4 (envelope.rs:41)
+    pub from: NodeId,
+    pub to: NodeId,
+    pub via: Vec<NodeId>,      // chaîne de relais
+    pub msg_type: MessageType,
+    pub payload: Vec<u8>,      // opaque (clair ou chiffré)
+    pub timestamp: u64,        // now_ms() Unix ms
+    pub signature: Vec<u8>,    // Ed25519 64o, vide si non signé
+    pub ttl: u32,              // compteur de sauts
+    pub encrypted: bool,
+}
+```
+- 10 champs, dérive `Serialize/Deserialize` (rmp-serde, array positionnel) — conforme spec §2.
+- `MessageType` = enum 36 variantes — `types.rs:7-50` (conforme aux 36 listées spec §4).
+- `MessageStatus` (Pending=0 → Sent → Relayed → Delivered → Read, Failed=5) — `types.rs:57-64`, `PartialOrd/Ord` monotone.
+
+### 2. signing_bytes() exclut ttl ? OUI ✅
+
+`envelope.rs:90-103` + `SignableEnvelope` `envelope.rs:274-284` : array de 8 champs, exclut `signature` (circularité) ET `ttl` (muté par relais — ADR-003). Vérifié par tests `signing_bytes_independent_of_ttl` (618), `ttl_mutation_does_not_break_signature` (622). `verify_signature` utilise `verify_strict` et rejette longueur ≠ 64 (`envelope.rs:138-152`). Conforme spec §3.
+
+### 3. Delivery semantics — `RoutingAction` (`router.rs:46-80`)
+
+Variantes réelles : `Deliver{envelope,response}`, `Ack{...}`, `ReadReceipt{...}`, `Forward{envelope,next_hop,relay_ack}`, `Reject{reason}`, **`ReAck{response}`**, `Drop`. (La variante `ReAck` n'est PAS dans la liste de tâche ni la spec — elle ré-émet l'ACK sur duplicata pour survivre à la perte d'ACK, `router.rs:74-77,224-233`.)
+
+- **Sémantique** : at-least-once + dédup côté récepteur. Duplicata → `ReAck` (ré-confirme, ne re-délivre pas), pas exactly-once mais delivery idempotente.
+- **ACK chiffré ?** NON — `create_delivery_ack`/`create_relay_ack` (`router.rs:365-385`) produisent un `Envelope` non chiffré (`encrypted=false`).
+- **ACK signé ?** OUI à l'émission : `state.rs:818,829,854` signent l'ACK avant envoi (`ack.sign(&self.secret_seed)`). ⚠️ **Contredit partiellement Known Limitation #5** ("ACK non signé") : l'ACK est bien signé sortant.
+
+### 4. ⚠️ ÉCART CONFIRMÉ — ACK entrant non vérifié (verrou #1)
+
+`handle_incoming` calcule `signature_valid` (`state.rs:1393-1397`) mais l'arm `RoutingAction::Ack` (`state.rs:872-891`) appelle `mark_delivered`/`mark_relayed` **sans consulter `signature_valid`**. `signature_valid` n'est attaché qu'au `DeliveredMessage` (chat), pas aux ACK. → un ACK forgé non signé fait passer un message à `Delivered`. **Viole verrou #1** (livré ⟺ ACK *du destinataire*). C'est le vrai fond de Known Limitation #5.
+
+### 5. TTL — deux notions (verrou #2)
+
+| Notion | Valeur | Code |
+|---|---|---|
+| TTL saut (hop) | `DEFAULT_TTL=4`, `MAX_TTL=4` | `types.rs:67-70` |
+| Décrément relais | à 0 → `Reject` | `envelope.rs:106-114`, `router.rs:332,348` |
+| Profondeur relais | `MAX_RELAY_DEPTH=4` | `router.rs:18,166` |
+| Lifespan message | 24h hard | `backup/types.rs:14 MAX_TTL_MS`, `state.rs:529 TTL_MS` |
+
+### 6. ⚠️ ÉCART CRITIQUE CONFIRMÉ — purge SQLite hub jamais déclenchée (verrou #2)
+
+`tick_hub_cleanup` (`state.rs:527-540`) :
+- in-mémoire : `cleanup_expired_messages(now, TTL_MS)` → `cutoff = now - max_age` correct (`hub.rs:127`). ✅
+- SQLite : `store.cleanup_hub_messages(TTL_MS)` passe **`TTL_MS=86_400_000` comme cutoff absolu**. Or `cleanup_hub_messages` exécute `DELETE ... WHERE stored_at < ?1` (`storage/mod.rs:277-284`) et `stored_at = now_ms()` (~1.7e12, `state.rs:2355`). Donc `stored_at < 86_400_000` **n'est jamais vrai** → la table `hub_message_history` **n'est JAMAIS purgée**. 
+
+**Fix** : `store.cleanup_hub_messages(now.saturating_sub(TTL_MS))`. C'est le dépassement de TTL réel (Known Limitation #5), localisé à `state.rs:536-537`. Le `BackupStore` (virus) est lui in-memory seul, purgé à 24h via `tick_backup`→`cleanup_expired` (`coordinator.rs:271`, loop.rs:350) et non persisté — conforme verrou #2.
+
+### 7. Routing — algo
+
+- `route()` (`router.rs:164-188`) : si `via.len() > 4` → Reject ; si `to == local` → local ; si dans `via` → forward chaîne ; sinon forward direct vers `to`.
+- **Multi-path** : NON. Chemin unique via `via[]` linéaire ou saut direct. Pas de multi-path/redondance.
+- **Hop limit** : double (TTL=4 + MAX_RELAY_DEPTH=4).
+- ACK retour via chaîne `via` inversée (`router.rs:372`).
+
+### 8. Dedup / anti-replay
+
+| Mécanisme | Clé | TTL purge | Code |
+|---|---|---|---|
+| Dedup message | `"{id}:{from}"` | 600s (DEDUP_TTL) | `router.rs:135,226,194` |
+| Anti-replay ACK/RR | `"{msgid}:{from}:{type}"` | 300s (ACK_TTL) | `router.rs:137,272,302` |
+| Nonce anti-replay (chiffré) | `[u8;24]` | 24h (NONCE_TTL) + LRU 50k | `router.rs:140,240-245,197-206` |
+
+Nonce : purge TTL 24h **présente** (`router.rs:37,197-206`) → **contredit Known Limitation #7** ("nonce sans purge TTL"). Le `(nonce,ts)` est stocké et time-purgé. ⚠️ Dédup/ACK caches sont des `HashMap` time-purgés **uniquement à `cleanup_caches()`** déclenché sur saturation (`MAX_CACHE_SIZE=10_000`) ; pas de tick périodique trouvé pour eux dans le router.
+
+### 9. Tableau écarts vs `tom-wire-v1.md`
+
+| Point spec | Spec | Code | Verdict |
+|---|---|---|---|
+| Envelope 10 champs array | §2 | `envelope.rs:14-35` | ✅ conforme |
+| signing_bytes exclut ttl+sig | §3 | `envelope.rs:90-103,274-284` | ✅ conforme |
+| TTL défaut/max = 4 | §5 | `types.rs:67-70` | ✅ conforme |
+| 36 MessageType | §4 | `types.rs:7-50` | ✅ conforme |
+| Statuts Pending→...→Read/Failed | §4 | `types.rs:57-64` | ✅ conforme |
+| Délivré ⟺ Ack destinataire | §6 | ACK entrant non vérifié signature (`state.rs:872-891`) | ❌ **écart verrou #1** |
+| Purge 24h message non livré | §5.2 | SQLite hub jamais purgé (`state.rs:536`) | ❌ **écart verrou #2** |
+| `RoutingAction` variantes | (tâche) | + `ReAck` non documentée | ⚠️ non-spec mais justifiée |
+
+### 10. Conformité verrous
+
+- **Verrou #1** (ACK⟺livré) : ❌ partiellement violé — ACK entrant non gaté par `signature_valid` ; un ACK forgé promeut à `Delivered`. Tracker monotone correct côté logique (`tracker.rs`, tests négatifs 538-570 ✅) mais l'entrée n'est pas authentifiée.
+- **Verrou #2** (purge 24h) : ❌ violé pour `hub_message_history` SQLite (cutoff bug `state.rs:536-537`). In-memory hub + backup virus conformes.
+
+**Bugs prioritaires** : (1) `state.rs:536` cutoff = `now - TTL_MS` ; (2) gater l'arm `RoutingAction::Ack` (`state.rs:872`) sur `signature_valid` + ACK signé requis.
+
+
+---
+
+## Annexe E — Groupes & Hubs
+
+Confirmed: members never *send* `HubUnreachable` in production — the runtime only *handles* it inbound. No member-side ACK-timeout logic emits it. So both promotion signals (`ping_failures`, `unreachable_reports`) stay 0 in production → **hub failover is entirely non-operational in the runtime**, despite being fully unit-tested at the manager level.
+
+Now let me verify the HubMigration trust issue and the rate-limit window reset edge. Let me check the `handle_member_left` retain (verrou 4 self-removal on kick) which I already saw. I have enough. Let me quickly verify the rate-limit reset edge counts correctly.
+
+The rate limit (hub.rs:769-785): on window reset it sets `(now, 1)` returns true; otherwise increments and checks `<= 5`. So within a 1s window it allows counts 1..=5 (5 messages) then blocks at 6th. Plus the message that triggered the reset. Effectively ~5/sec — correct, minor off-by-context but within spec.
+
+I have all findings. Let me produce the report.
+
+## Groups & Hubs Report
+
+### Structures réelles (code)
+
+**`GroupInfo`** — `crates/tom-protocol/src/group/types.rs:122-142`
+```rust
+pub struct GroupInfo {
+    group_id, name, hub_relay_id: NodeId, backup_hub_id: Option<NodeId>,
+    members: Vec<GroupMember>, created_by, created_at, last_activity_at,
+    max_members: usize, shadow_id: Option<NodeId>, candidate_id: Option<NodeId>,
+    invite_only: bool,
+}
+```
+- `MAX_GROUP_MEMBERS = 50` (`types.rs:13`), `MAX_SYNC_MESSAGES = 100` (`types.rs:25`).
+- `GroupMember` (`types.rs:111-117`) : `node_id, username, joined_at, role: GroupMemberRole {Admin|Member}` (`types.rs:100-106`).
+
+**`GroupMessage`** — `types.rs:354-378` : supporte plaintext + chiffré (sender key, XChaCha20 via `crypto::encrypt_group_message`), signé Ed25519 (`sign`/`verify_signature` `types.rs:470-495`), `seq` monotone assigné par le hub.
+
+**Backup `BackupEntry`** — `backup/types.rs:44-61` : `message_id, payload (opaque), recipient_id, sender_id, stored_at, expires_at, viability_score: u8, replicated_to: HashSet<NodeId>`.
+
+### Élection du hub (lowest NodeId)
+
+`group/election.rs:40-90` (`elect_hub`), déterministe :
+1. `backup_hub_id` si online et ≠ failed (`election.rs:46-58`) → `ElectionReason::Backup`.
+2. Sinon filtre `online_relays()` ≠ failed (`election.rs:61-70`).
+3. `candidates.sort_by_key(|a| a.to_string())` → `candidates[0]` (`election.rs:83-88`) → **lowest NodeId** confirmé. Déterminisme testé (`election.rs:232-247`).
+
+⚠️ **`elect_hub` n'est appelé NULLE PART en production.** Aucun appelant hors tests (`grep elect_hub` → seulement `election.rs`). La promotion réelle passe par `promote_to_primary` (shadow), pas par cette élection. L'élection déterministe documentée est du code mort runtime.
+
+### Failover Primary / Shadow / Candidate
+
+| Tier | Constante (types.rs) | Implémenté ? |
+|------|----------------------|--------------|
+| Shadow ping interval | `SHADOW_PING_INTERVAL_MS=3000` (`:31`) | ⚠️ const **inutilisée** (le loop a son propre timer `shadow_ping.tick()` `loop.rs:344`) |
+| Shadow ping timeout | `SHADOW_PING_TIMEOUT_MS=2000` (`:34`) | ❌ **inutilisée** — aucun détecteur de pong manquant |
+| Promote seuil | `SHADOW_PING_FAILURE_THRESHOLD=2` (`:37`) | partiel (`should_promote` `manager.rs:885`) |
+| Member→shadow timeout | `HUB_ACK_TIMEOUT_MS=3000` (`:40`) | ❌ **inutilisée** |
+| Candidate orphan | `CANDIDATE_ORPHAN_TIMEOUT_MS=30000` (`:43`) | ❌ **inutilisée** |
+| Hub heartbeat | `HUB_HEARTBEAT_INTERVAL_MS=30000`, `HUB_FAILURE_THRESHOLD=3` (`:19,22`) | ❌ **inutilisées** |
+
+Mécanique présente (`manager.rs`) : `tick_shadow_ping` envoie HubPing (`state.rs:498-525`, planifié `loop.rs:344`) ; primary répond HubPong (`state.rs:1059-1067`) ; shadow `reset_ping_failures` sur pong (`state.rs:1069`). Promotion `promote_to_primary` (`manager.rs:890-920`) → broadcast `HubMigration`.
+
+🔴 **RISQUE CRITIQUE — Failover non-opérationnel en production :**
+- `record_ping_failure` (`manager.rs:846`) n'est appelé **que dans les tests** (`grep` : tests uniquement, jamais dans `runtime/`). Aucune logique de timeout ne détecte un HubPong manquant → `ping_failures` reste **toujours 0** en prod.
+- `should_promote` (`manager.rs:880-887`) exige `ping_failures >= 2` **OU** `(ping_failures >= 1 && total >= 2)`. **Les deux branches exigent `ping_failures >= 1`.** ⇒ promotion **impossible** en production.
+- Les membres n'**émettent** jamais `HubUnreachable` (le runtime ne fait que le *recevoir*, `state.rs:1096`) ; aucune logique `HUB_ACK_TIMEOUT_MS` côté membre.
+- **Tier Candidate jamais implémenté** : `CandidateAssigned` est juste émis comme event (`state.rs:1089-1090`), aucune auto-promotion orpheline. La cascade « Primary→Shadow→Candidate » documentée se réduit à un Shadow inerte.
+
+→ **Conclusion failover : entièrement testé unitairement, mais mort au runtime.** Si le hub tombe, aucun basculement automatique ne se déclenche.
+
+### Split-brain
+
+`handle_hub_migration` (`manager.rs:449-465`) accepte **n'importe quel** `new_hub_id` sans vérifier que l'émetteur est le shadow/candidat légitime, ni cohérence avec une élection. `state.rs:1049-1055` ne valide pas non plus `envelope.from`. 🔴 **RISQUE : hijack de hub** — tout nœud envoyant `HubMigration` redirige le groupe vers un hub arbitraire (split-brain / détournement). Pas de garde anti-split-brain active (mitigé seulement par le fait que `promote_to_primary` est lui-même inatteignable, cf. ci-dessus).
+
+### Réplication backup (virus metaphor)
+
+`backup/coordinator.rs` + `store.rs`. Conforme :
+- **TTL 24h** : `MAX_TTL_MS = 24h` (`types.rs:14`), clampé à la création `ttl.min(MAX_TTL_MS)` (`types.rs:73`), réplicas refusés si expirés (`store.rs:81-83`). Purge `cleanup_expired` (`store.rs:199-224`) appelée dans `tick` (`coordinator.rs:271`). ✅ verrou 2.
+- **Self-delete sur ACK** : `confirm_delivery` (`coordinator.rs:166-192`) → `mark_delivered_batch` (suppression locale) + broadcast `ConfirmDelivery` aux porteurs de réplicas, qui purgent via `handle_delivery_confirmation` (`coordinator.rs:195-204`). ✅
+- **Réplication** : `MAX_REPLICAS=5` (`types.rs:32`), seuils viabilité `REPLICATION_THRESHOLD=30`, `DELETION_THRESHOLD=10` (`types.rs:26,29`).
+
+⚠️ Limites : (1) `viability_score` reçu d'un pair est stocké tel quel (`store.rs:107`) — non vérifié. (2) `MAX_TOTAL_MESSAGES=10_000` avec `evict_oldest` (`store.rs:14,55`) : éviction par capacité indépendante du TTL (perte possible <24h sous charge — aligné avec la limitation connue #5 du CLAUDE.md).
+
+### Membership (invite/join/leave/kick) — verrou 4
+
+- **Kick** (`hub.rs:921-966`) : admin-only (`is_admin` `:930`), pas d'auto-kick (`:935`), suppression par `members.retain` (`:945`). **Aucune liste de ban/blocklist.** Le membre kické peut **rejoindre immédiatement** (sauf `invite_only` + absent de `invited_set`, `hub.rs:319-323`). ✅ **verrou 4 respecté — aucun ban permanent.**
+- **Leave** (`hub.rs:400-435`) : `retain` volontaire.
+- **Join** (`hub.rs:296-368`) : re-sync si déjà membre, garde `invite_only`, `is_full()` (50). Self-removal local si kické (`manager.rs:350-365`).
+- ⚠️ `KickMember`/`UpdateMemberRole` non signés au niveau payload : autorisation reposant sur `is_admin` côté hub uniquement ; un faux hub pourrait forger `MemberLeft`.
+
+### Rate limiting (5 msg/s/sender)
+
+`hub.rs:769-785` : `GROUP_RATE_LIMIT_PER_SECOND=5` (`types.rs:28`), token simple par fenêtre 1s, `entry.1 <= 5`. Fonctionnel mais c'est une limite **dure** (drop), distincte de l'anti-spam progressif global. Acceptable au niveau hub (fan-out), pas en contradiction avec verrou 5 qui régit la couche transport.
+
+### Rôles — verrous 3/4/5
+
+- **Scoring** (`roles/scoring.rs`) : décroissance exponentielle `0.05/h` (`:8,110`), score **jamais 0** (testé `:171`). ✅ **fade progressif, verrou 4.**
+- **RoleManager** (`roles/manager.rs:161-208`) : promote ≥10, demote <2 ; agit **uniquement sur `topology` local** (rôle réseau émergent), n'arbitre rien de manière centralisée/L1. ✅ **verrou 3.**
+- **AntiSpam** (`roles/antispam.rs`) : token-bucket par score, `min_rate=30` jamais 0 même score négatif (`:163,243-244`), S-curve `min + range·score/(score+midpoint)`. ✅ **verrou 5 « sprinkler gets sprinkled ».**
+
+### Synthèse risques
+
+| # | Sévérité | Risque | Réf |
+|---|----------|--------|-----|
+| 1 | 🔴 Critique | **Failover hub mort au runtime** : `record_ping_failure` jamais appelé hors tests ; `should_promote` exige `ping_failures>=1` → promotion impossible | `manager.rs:846,880-887` ; `state.rs:498` ; `loop.rs:344` |
+| 2 | 🔴 Critique | **Membres n'émettent jamais HubUnreachable** (handler inbound seul) ; aucun `HUB_ACK_TIMEOUT_MS` côté membre | `state.rs:1096` ; const `types.rs:40` inutilisée |
+| 3 | 🔴 Élevé | **Split-brain / hub hijack** : `handle_hub_migration` accepte tout `new_hub_id` sans auth de l'émetteur | `manager.rs:449-465` ; `state.rs:1049-1055` |
+| 4 | 🟠 Moyen | **Tier Candidate non implémenté** ; `CANDIDATE_ORPHAN_TIMEOUT_MS` inutilisé ; cascade documentée incomplète | `types.rs:43` ; `state.rs:1089` |
+| 5 | 🟠 Moyen | **`elect_hub` (lowest NodeId) code mort** — non câblé au runtime | `election.rs:40` (aucun appelant prod) |
+| 6 | 🟠 Moyen | **Const heartbeat/ping inutilisées** : `HUB_HEARTBEAT_INTERVAL_MS`, `HUB_FAILURE_THRESHOLD`, `SHADOW_PING_INTERVAL_MS`, `SHADOW_PING_TIMEOUT_MS` (logique de détection absente) | `types.rs:19,22,31,34` |
+| 7 | 🟡 Faible | Kick/UpdateRole non signés payload — autorisation côté hub uniquement | `hub.rs:921,968` |
+| 8 | 🟡 Faible | Backup `viability_score` distant non vérifié ; éviction par capacité peut purger <24h | `store.rs:55,107` |
+
+**Conformité verrous : 3 ✅, 4 ✅, 5 ✅.** Le watchdog 3s/promote documenté existe en structures+tests mais n'est **pas raccordé au runtime** (risques 1-2, divergence majeure code/doc CLAUDE.md « watchdog 3s ping ~6s promote »).
+
+
+---
+
+## Annexe F — Tests & Qualité
+
+tom-connect est build+clippy mais jamais `cargo test`. Données complètes pour le rapport.
+
+## Tests & Quality Report — ToM Protocol
+
+### 1. Couverture de tests par crate (counts réels — `grep -rE '#\[(tokio::)?test\]'`)
+
+| Crate | Tests (#[test]+#[tokio::test]) | Dont src (unit) | Dont tests/ (intégration) | Fichiers tests/ |
+|---|---|---|---|---|
+| tom-protocol | **609** | 529 | 80 | 13 fichiers (backup, crypto_proptest, dht_e2e, discovery, e2e_routing, envelope_proptest, group, role_propagation, roles, runtime, signature_proptest, transport_relay_loop) |
+| tom-quinn-proto | 315 | majoritairement src/tests/ + proptest | — | — |
+| tom-connect | 78 | unit | — | aucun dossier tests/ |
+| tom-relay | 58 | unit + protos | — | — |
+| tom-transport | 36 | unit | — | `localhost.rs` |
+| tom-quinn | 25 | unit | — | — |
+| tom-protocol-ffi | 24 | unit | — | — |
+| tom-dht | 20 | unit | — | — |
+| tom-tui | 19 | unit | — | — |
+| tom-gateway | 13 | unit | — | — |
+| tom-gossip | 12 | unit | — | — |
+| tom-base | 9 | unit | — | — |
+| tom-integration-tests | 9 | — | 9 | `cross_machine.rs`, `multi_node.rs`, `peer_present_auto_discovery.rs` |
+| tom-metrics | 7 | unit | — | — |
+| tom-quinn-udp | 3 | unit | — | — |
+| tom-relay-ffi | 1 | unit | — | — |
+| tom-sdk | **0** | — | 0 (`two_clients.rs` existe, 0 `#[test]` détecté*) | `two_clients.rs` |
+| tom-stress | **0** | binaire, pas de #[test] | — | — |
+
+*Note: `tom-sdk/tests/two_clients.rs` existe mais `grep` n'y détecte aucun `#[test]`/`#[tokio::test]` — à vérifier (peut-être `#[test]` formaté autrement ou fichier vide/ignoré). **NON CONFIRMÉ au-delà du count grep = 0.**
+
+**Tests TypeScript (legacy):** 35 fichiers `*.test.ts` sous `packages/` (le CLAUDE.md annonce 771 tests — count par assertions non vérifié ici, seulement 35 fichiers).
+
+### 2. Types de tests présents
+
+- **Unit:** co-localisés `#[cfg(test)] mod tests` (majorité).
+- **Intégration:** `tom-protocol/tests/` (13 fichiers), `tom-integration-tests/` (cross-machine, multi-node, auto-discovery), `tom-transport/tests/localhost.rs`, `tom-sdk/tests/two_clients.rs`.
+- **Property-based (proptest):** `tom-protocol` (envelope, signature, crypto) + `tom-quinn-proto` (varint, range_set, frame, assembler, send_buffer, encode_decode) + `tom-relay` (protos/relay).
+- **Stress (`tom-stress`):** 8 scénarios via `scenario_runner.rs` — e2e, group, backup, failover, roles, chaos, partition, churn. Modes: `burst`, `fanout`, `ladder`, `ping`, `endurance`. Aucun `#[test]` (binaire exécuté en CI via `test-localhost.sh`).
+
+### 3. Pipeline CI (`.github/workflows/ci.yml` — déclenché push/PR sur `main`)
+
+10 jobs:
+
+| Job | Étapes réelles |
+|---|---|
+| `typescript` | `pnpm install --frozen-lockfile` → `build` → `test` → `lint` |
+| `observability-smoke` | `scripts/run-observability-smoke-local.sh` (relay + discovery) |
+| `rust-protocol` | build / test / clippy `-D warnings` sur **tom-protocol** uniquement |
+| `rust-transport` | build / test / clippy sur **tom-transport** |
+| `rust-fork` | build {base,metrics,quinn-proto,quinn,connect,relay,gossip} ; **test**: base, metrics, quinn-proto `--lib`, quinn `--lib`, relay `--lib`, gossip `--lib` ; clippy sur les 7 |
+| `rust-security` | `cargo-deny-action@v2 check advisories bans sources` |
+| `rust-ffi` | build+clippy `tom-relay-ffi` ; build+clippy `tom-protocol-ffi --locked` (exclu workspace) ; cbindgen header drift `--check` |
+| `rust-macos` | macos-latest: build `tom-relay-ffi` + `tom-protocol-ffi --locked` |
+| `rust-stress` | build+clippy `tom-stress` + `test-localhost.sh` (timeout 5min) |
+| `rust-poc` | `experiments/iroh-poc`: build/clippy/`test-localhost.sh` nat-test |
+
+**Release:**
+- `release.yml`: `release-please-action@v4` (release-type node) sur push `main`.
+- `release-sdk-swift.yml`: tag `sdk-swift/v*` → XCFramework (5 slices, nightly+rust-src) → checksum SPM → `swift build` validation → `gh release create`.
+
+### 4. Quality gates
+
+- **Lint:** `cargo clippy -- -D warnings` appliqué par job (protocol, transport, fork crates, ffi, stress, poc). PAS de `cargo clippy --workspace` en CI (couverture par-crate explicite).
+- **Format:** `rustfmt.toml` existe mais **défauts stables uniquement, aucune option** ; **aucun job CI ne lance `cargo fmt --check`** → format non vérifié en CI. **NON TROUVÉ DANS LE CODE** de step `fmt --check`.
+- **Supply chain:** `deny.toml` — advisories (équiv. cargo-audit) + bans + sources. 4 advisories ignorées (RUSTSEC-2026-0097 rand, 2026-0002 lru, 2024-0436 paste, 2023-0089 atomic-polyfill). `multiple-versions = "allow"`. Check `licenses` **différé** (non actif).
+- **Coverage tooling:** **NON TROUVÉ DANS LE CODE** (aucun tarpaulin/llvm-cov/grcov/codecov en `.github/` ou `scripts/`).
+- **FFI:** exclu du workspace, couvert par job `rust-ffi`/`rust-macos` + `scripts/check-ffi.sh` (rejoue les 5 étapes).
+- **pre-push-gate.sh:** ⚠️ détecte la stack via `package.json` racine → `STACK=node` → lance `npm run lint/build/test`, **JAMAIS cargo**. La gate locale **ne teste pas le code Rust** (faux confort — contredit l'attente §24 du CLAUDE.md).
+
+### 5. Gaps de couverture priorisés
+
+**Critique:**
+1. **`pre-push-gate.sh` ignore Rust** (`scripts/pre-push-gate.sh:70-84`): stack détectée `node`, donc gate locale verte sans compiler/tester une seule ligne Rust. Le gros du codebase échappe au gate avant push.
+2. **`tom-connect` (78 tests) jamais exécuté en CI**: seulement `cargo build`+`clippy` (`ci.yml:110,126`), pas de `cargo test -p tom-connect`. 78 tests morts en CI.
+3. **`tom-dht` (20 tests) absent de CI**: ni build ni test direct, alors que c'est le cœur du rendez-vous zéro-config (ADR-010) et marqué "trous ouverts" (squatting).
+
+**Haut:**
+4. **`tom-integration-tests` (9 tests intégration) absent de CI** — cross-machine/multi-node/auto-discovery jamais lancés.
+5. **`tom-gateway` (13) et `tom-tui` (19) absents de CI** — ni build ni test.
+6. **`tom-sdk`: 0 test détecté** malgré `tests/two_clients.rs` (à confirmer) — SDK consommateur non couvert en CI.
+7. **`tom-quinn-proto`/`tom-quinn`/`tom-relay`/`tom-gossip` testés en `--lib` seulement** (`ci.yml:116-123`) → tests d'intégration (`tests/`) de ces crates non exécutés.
+
+**Moyen:**
+8. **Pas de `cargo fmt --check` en CI** — `rustfmt.toml` purement déclaratif, format non garanti.
+9. **Pas de coverage mesurée** (aucun outil) — impossible de chiffrer la couverture réelle, seulement le nombre de tests.
+10. **`cargo-deny licenses` désactivé** — risque licence non vérifié (allowlist non constituée).
+11. **`tom-quinn-udp` (exclu workspace, 3 tests)** non couvert en CI.
+
+**Synthèse counts:** ~1278 tests Rust `#[test]`/`#[tokio::test]` au total (somme colonne), dont **seuls ~1009 sont effectivement exécutés en Cate** (tom-protocol 609 + fork crates en `--lib` + transport 36) ; **tom-connect (78), tom-dht (20), tom-gateway (13), tom-tui (19), tom-integration-tests (9)** = ~139 tests jamais lancés par la CI.
+
+
+---


### PR DESCRIPTION
## Audit complet du codebase ToM Protocol

Audit multi-agent (6 agents spécialisés + synthèse consolidée) écrit dans `docs/audits/AUDIT-2026-06-26.md`. **Documentation uniquement, aucun changement de code.** Règle zéro-hallucination : chaque affirmation tracée à `fichier:ligne`, sinon "NON TROUVÉ DANS LE CODE".

### Verdict — Conformité 7 verrous : 5 ✅ · 1 ⚠️ · 1 ❌

| # | Verrou | Statut |
|---|--------|--------|
| 1 | ACK destinataire ⟺ livré | ❌ ACK **entrant** non gaté sur `signature_valid` (`state.rs:872`) |
| 2 | TTL 24h purge globale | ⚠️ Backup OK, mais purge SQLite hub buggée (cutoff `state.rs:536`) |
| 3 | L1 ancre, jamais arbitre | ✅ |
| 4 | Réputation fade, pas de ban | ✅ |
| 5 | Anti-spam progressif | ✅ |
| 6 | Protocole invisible | ✅ |
| 7 | Fondation universelle | ✅ |

### Maturité par composant
- 🟢 **Crypto** / **Transport** — production, terrain validé (holepunch 100% LAN/4G/cross-border)
- 🟡 **Protocol / Routing**, **SDK/FFI**, **Tests/CI**, **Discovery DHT**
- 🔴 **Groups / Failover** — failover hub **mort au runtime**, split-brain non gardé

### Écarts critiques confirmés (corrigeables, pas des défauts de conception)
1. **Purge SQLite hub jamais déclenchée** (verrou #2, trivial) — `state.rs:536`
2. **ACK entrant non vérifié** (verrou #1, faible) — `state.rs:872`
3. **Failover hub non câblé** : `should_promote` impossible, `record_ping_failure` jamais appelé hors tests
4. **Split-brain / hub hijack** : `handle_hub_migration` accepte tout `new_hub_id`
5. **Double-version ed25519-dalek** (2.2.0 + 3.0.0-pre.1) viole le pin documenté
6. **pre-push-gate ignore Rust** ; tom-connect/dht/integration absents de CI
7. **Doc ≠ code** : wire invariants `.tom.invalid`/`X-Tom-*` → tom-relay **pas** wire-compatible iroh (contredit CLAUDE.md)

Détails complets + 6 rapports d'agents en annexe dans le fichier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7FJU1kdbag5ssKuNtQowD)_